### PR TITLE
Modified scheduler and monitor codes to run jobs on one or more nodes

### DIFF
--- a/docker/main/nwm/make_temp_dir.sh
+++ b/docker/main/nwm/make_temp_dir.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+num_hosts=$1
+num_hosts=$((num_hosts + 0))
+idx=0
+for str in $@
+do
+    if [ $idx -ne 0 ] && [ $idx -le $num_hosts ]; then
+        name=`echo $str | cut -d ':' -f 1`
+        req_id=`echo $name | cut -d '_' -f 4`
+        #echo $req_id
+    fi
+    ((idx++))
+done
+echo ${req_id}
+
+cd /nwm
+domain_location=/nwm/domains
+tmp_domain=/nwm/domains/tmp_${req_id}
+mkdir -p $tmp_domain
+ln -s $domain_location/example_case/NWM/* $tmp_domain/
+
+sudo /usr/sbin/sshd -D 

--- a/docker/main/nwm/run_model.sh
+++ b/docker/main/nwm/run_model.sh
@@ -1,19 +1,36 @@
 #!/bin/bash
 
-cd /nwm
-
-domain_location=/nwm/domains
-tmp_domain=/nwm/domains/tmp_$(hostname)
-mkdir -p $tmp_domain
+# Wait a bit to make sure all service workers are up
+sleep 15
 
 num_hosts=$1
 num_hosts=$((num_hosts + 0))
+idx=0
+for str in $@
+do
+    if [ $idx -ne 0 ] && [ $idx -le $num_hosts ]; then
+        name=`echo $str | cut -d ':' -f 1`
+        req_id=`echo $name | cut -d '_' -f 4`
+        #echo $req_id
+    fi
+    ((idx++))
+done
+echo ${req_id}
 
+cd /nwm
+domain_location=/nwm/domains
+tmp_domain=/nwm/domains/tmp_${req_id}
+mkdir -p $tmp_domain
+ln -s $domain_location/example_case/NWM/* $tmp_domain/
+
+run_dir=$tmp_domain
+cd $run_dir
+
+# Parsing host_str and write to hostfile
 idx=0
 for str in $@
 do
     if [ $idx -eq 0 ]; then
-        # echo $str >> hostfile1
         echo $str
     elif [ $idx -eq 1 ]; then
         echo $str > hostfile
@@ -25,23 +42,18 @@ do
     ((idx++))
 done
 
-ln -s ${run_domain_dir}/* $tmp_domain/
-run_dir=$tmp_domain
-cd $run_dir
-cp /nwm/hostfile .
-
 total_cpus=0
 for host in `cat hostfile`; do
     cpus=`echo $host | cut -d ':' -f 2`
     ((total_cpus = total_cpus+$cpus))
 done
 
-echo 'starting mpirun'
-echo $(date)
 /usr/local/bin/mpirun -f hostfile -n $total_cpus wrf_hydro.exe
 mpi_rtn_val=$?
 echo 'mpirun returned with a return value: ' $mpi_rtn_val
 echo $(date)
-sleep 30
-# exit $mpi_rtn_val	# Running this command will stop the container
+sleep 10    # wait to see the time interval before job being resubmitted
+exit $mpi_rtn_val
+
 sudo /usr/sbin/sshd -D 
+


### PR DESCRIPTION
Modified the refactored scheduler and queue monitor codes to run on one or more nodes.
The leading worker has now been changed to worker0

## Additions
docker/main/nwm/make_temp_dir.sh

## Removals

-

## Changes
docker/main/nwm/run_model.sh
modified:   python/lib/monitor/dmod/monitor/que_monitor.py
modified:   python/lib/scheduler/dmod/scheduler/scheduler.py

## Testing
Tested as standalone codes

## Screenshots


## Notes
Some fixes as commented in the refactored codes remain to be implemented

## Todos
Test the changes on interfacing with SchedulerRequestMessage
Implement functionality in monitor code to read/write the same queue info through Redis

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] No linting errors or warnings
