### PR TITLE
Fixes for unit testing

### DIFF
--- a/python/lib/communication/dmod/test/test_scheduler_request_message.py
+++ b/python/lib/communication/dmod/test/test_scheduler_request_message.py
@@ -14,18 +14,19 @@ class TestSchedulerRequestMessage(unittest.TestCase):
 
         # Example 0
         self.request_strings.append(
-            '{"model_request": {"model": {"NWM": {"version": 2.0, "output": "streamflow", "parameters": {}}}, "session-secret": "f21f27ac3d443c0948aab924bddefc64891c455a756ca77a4d86ec2f697cd13c"}, "user_id": "someone", "cpus": 4, "mem": 500000}')
+            '{"model_request": {"model": {"NWM": {"version": 2.0, "output": "streamflow", "parameters": {}}}, "session-secret": "f21f27ac3d443c0948aab924bddefc64891c455a756ca77a4d86ec2f697cd13c"}, "user_id": "someone", "cpus": 4, "mem": 500000, "allocation": "single-node"}')
         self.request_jsons.append({"model_request": {
             "model": {"NWM": {"version": 2.0, "output": "streamflow", "parameters": {}}},
             "session-secret": "f21f27ac3d443c0948aab924bddefc64891c455a756ca77a4d86ec2f697cd13c"}, "user_id": "someone",
-                                   "cpus": 4, "mem": 500000})
+                                   "cpus": 4, "mem": 500000, "allocation": "single-node"})
         self.request_objs.append(
             SchedulerRequestMessage(model_request=NWMRequest.factory_init_from_deserialized_json(
                 {"model": {"NWM": {"version": 2.0, "output": "streamflow", "parameters": {}}},
                  "session-secret": "f21f27ac3d443c0948aab924bddefc64891c455a756ca77a4d86ec2f697cd13c"}),
                                     user_id='someone',
                                     cpus=4,
-                                    mem=500000))
+                                    mem=500000,
+                                    allocation_paradigm='single-node'))
 
     def test_factory_init_from_deserialized_json_0_a(self):
         """

--- a/python/lib/scheduler/dmod/test/test_scheduler.py
+++ b/python/lib/scheduler/dmod/test/test_scheduler.py
@@ -3,6 +3,26 @@ from pathlib import Path
 from ..scheduler.scheduler import Launcher
 from . import mock_job
 
+
+class NoCheckDockerLauncher(Launcher):
+    """
+    Extension of Docker launcher class, strictly for unit testing, which overrides the implementation of the
+    ::method:`Launcher.checkDocker` method to not perform check of the OS-level Docker application/service.
+    """
+
+    def __init__(self, images_and_domains_yaml, docker_client=None, api_client=None, **kwargs):
+        super().__init__(images_and_domains_yaml=images_and_domains_yaml,
+                         docker_client=docker_client,
+                         api_client=api_client,
+                         **kwargs)
+
+    def checkDocker(self):
+        """
+        Override of superclass method to not actually perform check (i.e., when unit testing).
+        """
+        pass
+
+
 class TestLauncher(unittest.TestCase):
 
     def setUp(self) -> None:
@@ -10,7 +30,7 @@ class TestLauncher(unittest.TestCase):
         self.user_name = 'test'
 
         #Create a launcher TODO only test static methods here, no instance so no docker neeeded
-        self.launcher = Launcher(images_and_domains_yaml=yaml_file)
+        self.launcher = NoCheckDockerLauncher(images_and_domains_yaml=yaml_file)
 
     def tearDown(self) -> None:
         #This class should only test static methods and work without docker FIXME

--- a/python/services/requestservice/dmod/test/test_request_handler.py
+++ b/python/services/requestservice/dmod/test/test_request_handler.py
@@ -10,6 +10,7 @@ import ssl
 import unittest
 
 
+# TODO: consider removing
 class TestRequestHandler(unittest.TestCase):
     _current_dir = Path(__file__).resolve().parent
     _json_schemas_dir = _current_dir.parent.joinpath('schemas')
@@ -20,8 +21,9 @@ class TestRequestHandler(unittest.TestCase):
     _ssl_dir = _current_dir.parent.parent.joinpath('communication', 'ssl')
     _localhost_pem = _ssl_dir.joinpath('certificate.pem')
     _host_name = gethostname()
-    
-    _client_ssl_context.load_verify_locations(_localhost_pem)
+
+    # TODO: may need to uncomment this if any tests are actually added to this class
+    #_client_ssl_context.load_verify_locations(_localhost_pem)
 
     @staticmethod
     def run_coroutine(coroutine):

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -80,16 +80,26 @@ determine_supported_packages()
     spi=0
     for i in ${LIB_PACKAGE_DIRS[@]}; do
         if [ $(find ${i} -type d -name test | wc -l) -gt 0 ]; then
-            SUPPORTED_PACKAGES[${spi}]="${i}"
-            spi=$((spi+1))
+            for j in $(find ${i} -type d -name test); do
+                if [ $(find ${j} -type f -name "*.py" | wc -l) -gt 0 ]; then
+                    SUPPORTED_PACKAGES[${spi}]="${i}"
+                    spi=$((spi+1))
+                    break
+                fi
+            done
         fi
     done
 
     if [ -n "${DO_SERVICE_PACKAGES:-}" ]; then
         for i in ${SERVICE_PACKAGE_DIRS[@]}; do
             if [ $(find ${i} -type d -name test | wc -l) -gt 0 ]; then
-                SUPPORTED_PACKAGES[${spi}]="${i}"
-                spi=$((spi+1))
+                for j in $(find ${i} -type d -name test); do
+                    if [ $(find ${j} -type f -name "*.py" | wc -l) -gt 0 ]; then
+                        SUPPORTED_PACKAGES[${spi}]="${i}"
+                        spi=$((spi+1))
+                        break
+                    fi
+                done
             fi
         done
     fi

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -220,6 +220,8 @@ if [ -z "${SET_VERBOSE:-}" ]; then
     echo ""
 fi
 
+TOTAL_RESULT=0
+
 # Perform testing on the supported packages
 len=${#SUPPORTED_PACKAGES[@]}
 for (( i=0; i<${len}; i++)); do
@@ -231,6 +233,7 @@ for (( i=0; i<${len}; i++)); do
         _TEMP_FILE="./.run_tests_temp_package_test_output_${i}"
         test_package ${i} > "${_TEMP_FILE}" 2>&1
         _P_RES=${PACKAGE_RESULT[${i}]}
+        [ ${_P_RES} -eq 0 ] || TOTAL_RESULT=$((TOTAL_RESULT+1))
         _TEST_COUNTS=`cat "${_TEMP_FILE}" | grep Ran`
         _RESULTS=`cat "${_TEMP_FILE}" | tail -n 5 | grep -i 'fail\|ok'`
         echo "${SUPPORTED_PACKAGES[${i}]}: ${_RESULTS} (${_TEST_COUNTS})"
@@ -245,8 +248,6 @@ for (( i=0; i<${len}; i++)); do
         echo ""
     fi
 done
-
-TOTAL_RESULT=0
 
 # If we got verbose output, print summary at the end, along with something extra to have stand out
 if [ -n "${SET_VERBOSE:-}" ]; then


### PR DESCRIPTION
Fixing unit tests and automation tools.

- Correction to how Python testing helper scripts detect packages that should be tested.
- Ensuring return code for multi-package Python test helper script reflects whether there were failures.
- Fixes to some current unit tests that were failing.
