### PR TITLE
Update dockerfile for missing dependencies required for build, fixes #20

### DIFF
--- a/docker/py_sources/py_sources.Dockerfile
+++ b/docker/py_sources/py_sources.Dockerfile
@@ -29,7 +29,7 @@ ARG externalrequests_package_name
 ARG scheduler_package_name
 # Set this so script below will not run logic that only applies to when in a full Git repo directory tree
 ENV OUT_OF_GIT_REPO=true
-RUN for p in communication access externalrequests scheduler; do \
+RUN for p in communication access externalrequests scheduler redis; do \
         ./scripts/dist_package.sh --sys python/lib/${p} && mv python/lib/${p}/dist/*.whl /DIST/.; \
     done
 ################################################################################################################

--- a/docker/py_sources/py_sources.Dockerfile
+++ b/docker/py_sources/py_sources.Dockerfile
@@ -2,6 +2,8 @@
 ################################################################################################################
 ##### Create base level intermediate build stage
 FROM python:3.7-alpine as basis
+ARG REQUIRE="gcc musl-dev libffi-dev"
+RUN apk update && apk upgrade && apk add --no-cache ${REQUIRE}
 # Copy project requirements file, which should have everything needed to build any package within project
 COPY ./requirements.txt /nwm_service/requirements.txt
 # Along with setup and wheel to build, install all project pip dependencies for package building later


### PR DESCRIPTION
I'm assuming something upstream in the python based image dropped a few dependencies that are required for some of the wheel installs in the `py_sources` docker file.  This PR makes this build succeed once more.

Also, the `redis` subpackage in `communications` was missing from the build stage, added to complete the build of py_sources required for building all current service packages.
## Additions

- Add explicit `gcc`, `musl-dev`, and `libffi-dev` installs in `py_sources.dockerifle`

## Testing

Build successful

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
