### PR TITLE
Fix nwm deps image build

### DIFF
--- a/docker/main/base/Dockerfile
+++ b/docker/main/base/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.4
+FROM alpine:3.10
 # In case the main package repositories are down, use the alternative base image:
-# FROM gliderlabs/alpine:3.4
+# FROM gliderlabs/alpine:3.10
 
 ARG REPOS=""
 ARG REQUIRE="sudo openssh bash"

--- a/docker/main/nwm/deps/Dockerfile
+++ b/docker/main/nwm/deps/Dockerfile
@@ -6,7 +6,7 @@ FROM ${DOCKER_INTERNAL_REGISTRY}/nwm-base
 USER root
 ARG REPOS="http://dl-cdn.alpinelinux.org/alpine/edge/testing"
 # Building hdf5 from source for parallel support, otherwise add hdf5 hdf5-dev to the list below
-ARG REQUIRE="sudo build-base gfortran openssl curl curl-dev tar git m4 zlib-dev"
+ARG REQUIRE="sudo build-base gfortran openssl curl curl-dev tar git m4 zlib-dev libexecinfo-dev"
 
 # ARG NETCDF_C_VERSION="latest"
 #ARG NETCDF_C_VERSION="v4.6.0"


### PR DESCRIPTION
Need to build HDF5 in nwm deps image. It turns out to be simpler just to bump the base to alpine 3.10 where libexecinfo in the main package repository compared to trying to pull in the package on 3.4

## Additions

- add `libexecinfo-dev` to apk required packages

## Changes

- bump base alpine version to 3.10

## Testing

Build succeeds.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Docker
