### PR TITLE
Ngen docker container for use in DMOD

### DIFF
--- a/docker/main/base/Dockerfile
+++ b/docker/main/base/Dockerfile
@@ -4,10 +4,10 @@ FROM alpine:3.12
 
 ARG REPOS=""
 ARG REQUIRE="sudo openssh bash"
-ARG WORKDIR=/nwm
+
 ARG USER=mpi
 
-ENV USER=${USER} USER_HOME=/home/${USER}  WORKDIR=${WORKDIR}
+ENV USER=${USER} USER_HOME=/home/${USER}
 ENV SSHDIR=${USER_HOME}/.ssh
 RUN apk update && apk upgrade \
     && apk add --repository ${REPOS} --no-cache ${REQUIRE} \
@@ -15,11 +15,6 @@ RUN apk update && apk upgrade \
     && adduser -D ${USER} \
     && echo "${USER}   ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
     && chown -R ${USER}:${USER} ${USER_HOME} \
-    #### CREATE WORKING DIRECTORY FOR USER #### \
-    && mkdir ${WORKDIR} \
-    && chown -R ${USER}:${USER} ${WORKDIR} \
-    # Auto go to default working directory when user ssh login \
-    && echo "cd $WORKDIR" >> ${USER_HOME}/.profile \
     # # ------------------------------------------------------------ \
     # # Set up SSH Server \
     # # ------------------------------------------------------------ \
@@ -50,4 +45,3 @@ RUN cat ${SSHDIR}/*.pub >> ${SSHDIR}/authorized_keys \
 
 # Switch back to default user when continue the build process
 USER ${USER}
-WORKDIR ${WORKDIR}

--- a/docker/main/base/Dockerfile
+++ b/docker/main/base/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.10
+FROM alpine:3.12
 # In case the main package repositories are down, use the alternative base image:
-# FROM gliderlabs/alpine:3.10
+# FROM gliderlabs/alpine:3.12
 
 ARG REPOS=""
 ARG REQUIRE="sudo openssh bash"

--- a/docker/main/docker-build.yml
+++ b/docker/main/docker-build.yml
@@ -34,6 +34,27 @@ services:
         COMMIT: ${NWM_COMMIT}
         DOCKER_INTERNAL_REGISTRY: ${DOCKER_INTERNAL_REGISTRY:?}
         NETCDF_C_VERSION: ${NETCDF_C_VERSION:-latest}
+
+  ngen-deps:
+    image: ${DOCKER_INTERNAL_REGISTRY:?}/ngen-deps:latest
+    build:
+      context: ./ngen/deps
+      args:
+        DOCKER_INTERNAL_REGISTRY: ${DOCKER_INTERNAL_REGISTRY:?}
+    depends_on:
+      - base
+
+  ngen:
+    image: ${DOCKER_INTERNAL_REGISTRY:?}/ngen-${NGEN_NAME:-master}
+    build:
+      context: ./ngen
+      args:
+        REPO_URL: ${NGEN_REPO_URL?}
+        BRANCH: ${NGEN_BRANCH?}
+        COMMIT: ${NGEN_COMMIT}
+        DOCKER_INTERNAL_REGISTRY: ${DOCKER_INTERNAL_REGISTRY:?}
+    depends_on:
+      - ngen-deps
     #depends_on:
     #    - deps
     #For building, this only gives shared memory to each build step!!! shm_size: 2GB

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -1,0 +1,42 @@
+ARG DOCKER_INTERNAL_REGISTRY
+#FIXME is base no longer nwm specific??? How about deps?
+#Base is missing a few simple deps, like git...
+#FROM ${DOCKER_INTERNAL_REGISTRY}/nwm-base
+FROM ${DOCKER_INTERNAL_REGISTRY}/ngen-deps:latest
+
+#Passing the ARG variables from compose via .env file will squash these defaults with empty strings
+#Seems like the work around is to replicate the default values in the build env, or to check for
+#empty and set to default as is shown commented out below.
+ARG REPO_URL=https://github.com/NOAA-OWP/ngen.git
+ARG BRANCH=master
+ARG COMMIT
+ENV PATH "${WORKDIR}/bin:${PATH}"
+ARG BOOST_VERSION=1.72.0
+ENV BOOST_ROOT=${WORKDIR}/boost
+
+RUN wget https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION//./_}.tar.gz \
+    #### \
+    # Get boost headers \
+    #### \
+    && mkdir -p ${WORKDIR}/boost \
+    && tar zxf boost_${BOOST_VERSION//./_}.tar.gz -C ./boost --strip-components=1 \
+    && rm boost_${BOOST_VERSION//./_}.tar.gz \
+    && git clone --single-branch --branch $BRANCH $REPO_URL \
+    && cd ./ngen \
+    && git submodule update --init --recursive -- test/googletest \
+    && if [ "x$COMMIT" != "x" ]; then git checkout $COMMIT; fi \
+    && cmake -B cmake-build -S . -DCMAKE_INSTALL_PREFIX=${WORKDIR} \
+    && cmake --build cmake-build -j 8 \
+    #Run the tests, if they fail, the image build fails \
+    && cmake-build/test/test_all \
+    #FIXME remove the data copy, only there for temporary testing \
+    && mkdir ${WORKDIR}/bin && cp cmake-build/ngen ${WORKDIR}/bin && cp -r data ${WORKDIR}/data \
+    && cd $WORKDIR && rm -rf ngen boost
+
+USER root
+#Remove the boost headers now that ngen is compiled
+RUN rm -rf ${BOOST_ROOT}
+RUN echo "export PATH=${PATH}" >> /etc/profile
+USER ${USER}
+#COPY run_model.sh ${WORKDIR}
+WORKDIR ${WORKDIR}

--- a/docker/main/ngen/deps/Dockerfile
+++ b/docker/main/ngen/deps/Dockerfile
@@ -1,0 +1,65 @@
+ARG DOCKER_INTERNAL_REGISTRY
+FROM ${DOCKER_INTERNAL_REGISTRY}/nwm-base
+
+USER root
+
+########################################
+# Model specific ENV
+########################################
+ARG WORKDIR=/ngen
+ENV WORKDIR=${WORKDIR}
+#### CREATE WORKING DIRECTORY FOR MODEL #### \
+RUN mkdir ${WORKDIR} \
+    && chown -R ${USER}:${USER} ${WORKDIR} \
+    # Auto go to default working directory when user ssh login \
+    && echo "cd $WORKDIR" >> ${USER_HOME}/.profile \
+WORKDIR ${WORKDIR}
+
+########################################
+# Model specific dependencies/builds
+########################################
+
+#ARG REPOS="http://dl-cdn.alpinelinux.org/alpine/edge/testing"
+ARG REQUIRE="sudo gcc g++ musl-dev make cmake tar git"
+
+#Eventually, MPI probably required for ngen
+ENV HYDRA_HOST_FILE /etc/opt/hosts
+# MPICH Build Options:
+# See installation guide of target MPICH version
+# Ex: http://www.mpich.org/static/downloads/3.2/mpich-3.2-installguide.pdf
+# These options are passed to the steps below
+#ARG MPICH_VERSION="3.2"
+#ARG MPICH_CONFIGURE_OPTIONS="--disable-fortran"
+#ARG MPICH_MAKE_OPTIONS
+
+### INSTALL MPICH ####
+# Source is available at http://www.mpich.org/static/downloads/
+# Download, build, and install MPICH
+
+RUN apk update && apk upgrade && apk add --repository ${REPOS} --no-cache ${REQUIRE}
+    #### \
+    # MPICH build and install \
+    #### \
+#    && mkdir /tmp/mpich-src \
+#    && cd /tmp/mpich-src \
+#    && wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz \
+#    && tar xfz mpich-${MPICH_VERSION}.tar.gz  \
+#    && cd mpich-${MPICH_VERSION}  \
+#    && ./configure ${MPICH_CONFIGURE_OPTIONS}  \
+#    && make -j 8 ${MPICH_MAKE_OPTIONS} && make install \
+#    && cd /tmp \
+#    && rm -rf /tmp/mpich-src \
+    #### \
+    #   Configure MPI \
+    #### \
+    # Hostfile location for mpirun. This file will be updated automatically. \
+#    && echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
+#    && touch ${HYDRA_HOST_FILE} \
+#    && chown ${USER}:${USER} ${HYDRA_HOST_FILE} \
+#    && mkdir -p ${WORKDIR}/domains
+
+USER ${USER}
+####
+#   Pull latest ngen and build
+####
+WORKDIR ${WORKDIR}

--- a/docker/main/nwm/Dockerfile
+++ b/docker/main/nwm/Dockerfile
@@ -7,7 +7,7 @@ FROM ${DOCKER_INTERNAL_REGISTRY}/nwm-deps:netcdf_${NETCDF_C_VERSION:-latest}
 ARG REPO_URL=https://github.com/NCAR/wrf_hydro_nwm_public.git
 ARG BRANCH=master
 ARG COMMIT
-ENV PATH "/nwm/wrf_hydro_nwm_public/trunk/NDHMS/Run:${PATH}"
+ENV PATH "/${WORKDIR}/wrf_hydro_nwm_public/trunk/NDHMS/Run:${PATH}"
 
 #RUN if [ "x$REPO_URL" = "x" ]; then REPO_URL="https://github.com/NCAR/wrf_hydro_nwm_public.git"; fi && \
 #    if [ "x$NWM_BRANCH" = "x" ]; then NWM_BRANCH=master; fi && \
@@ -24,5 +24,5 @@ RUN echo "export PATH=${PATH}" >> /etc/profile
 #RUN apk add elfutils-libelf --repository http://dl-cdn.alpinelinux.org/alpine/edge/main
 #RUN apk add --update perf --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
 USER ${USER}
-COPY run_model.sh /nwm/
-WORKDIR /nwm/domains
+COPY run_model.sh /${WORKDIR}/
+WORKDIR ${WORKDIR}/domains

--- a/docker/main/nwm/deps/Dockerfile
+++ b/docker/main/nwm/deps/Dockerfile
@@ -3,7 +3,25 @@ ARG DOCKER_INTERNAL_REGISTRY
 FROM ${DOCKER_INTERNAL_REGISTRY}/nwm-base
 # In case the main package repositories are down, use the alternative base image:
 # FROM gliderlabs/alpine:3.4
+
 USER root
+
+########################################
+# Model specific ENV
+########################################
+ARG WORKDIR=/nwm
+ENV WORKDIR=${WORKDIR}
+#### CREATE WORKING DIRECTORY FOR MODEL #### \
+RUN mkdir ${WORKDIR} \
+    && chown -R ${USER}:${USER} ${WORKDIR} \
+    # Auto go to default working directory when user ssh login \
+    && echo "cd $WORKDIR" >> ${USER_HOME}/.profile \
+WORKDIR ${WORKDIR}
+
+########################################
+# Model specific dependencies/builds
+########################################
+
 ARG REPOS="http://dl-cdn.alpinelinux.org/alpine/edge/testing"
 # Building hdf5 from source for parallel support, otherwise add hdf5 hdf5-dev to the list below
 ARG REQUIRE="sudo build-base gfortran openssl curl curl-dev tar git m4 zlib-dev libexecinfo-dev"
@@ -84,10 +102,10 @@ RUN apk update && apk upgrade && apk add --repository ${REPOS} --no-cache ${REQU
     && echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && touch ${HYDRA_HOST_FILE} \
     && chown ${USER}:${USER} ${HYDRA_HOST_FILE} \
-    && mkdir -p /nwm/domains
+    && mkdir -p ${WORKDIR}/domains
 
 USER ${USER}
 ####
 #   Pull latest NWM and build
 ####
-WORKDIR /nwm
+WORKDIR ${WORKDIR}


### PR DESCRIPTION
To prepare support for NGEN, a docker container to run NGEN is needed run ngen jobs.
The changes in this PR should be reflective of what additions are required for DMOD to be AWARE of a new model it can execute.  This does NOT hook the model into the request handler or the scheduler at this time.

## Additions

-  an NGEN docker file and dependency layer

## Changes

- Bump base alpine image to 3.12
- Move WORKDIR ENV handling to dependency layer instead of base.

## Testing

1. Running `control_stack.sh` to build main stack, succesfully builds and pushes ngen image.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Docker