### PR TITLE
Make sure py-sources builds all source dependencies as wheels, fixes #33

### DIFF
--- a/docker/py-sources/py-sources.Dockerfile
+++ b/docker/py-sources/py-sources.Dockerfile
@@ -2,12 +2,12 @@
 ################################################################################################################
 ##### Create base level intermediate build stage
 FROM python:3.7-alpine as basis
-ARG REQUIRE="gcc musl-dev libffi-dev"
+ARG REQUIRE="gcc musl-dev libffi-dev openssl-dev"
 RUN apk update && apk upgrade && apk add --no-cache ${REQUIRE}
 # Copy project requirements file, which should have everything needed to build any package within project
 COPY ./requirements.txt /nwm_service/requirements.txt
 # Along with setup and wheel to build, install all project pip dependencies for package building later
-RUN mkdir /DIST && pip download --no-cache-dir --destination-directory /DIST -r /nwm_service/requirements.txt
+RUN mkdir /DIST && pip wheel --no-cache-dir -w /DIST -r /nwm_service/requirements.txt
 # Needed for sourced functions used by build scripts in later stages
 RUN mkdir -p /nwm_service/scripts/shared
 COPY ./scripts/dist_package.sh /nwm_service/scripts


### PR DESCRIPTION
Fixing #33 by making sure pip builds all wheels in the py-sources build stage.

## Changes

- have pip build the wheels, not just download the dependencies

## Testing

1. rebuilt all images successfully

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Docker
