### PR TITLE
Scheduler service fixes

### DIFF
--- a/python/lib/scheduler/dmod/scheduler/__init__.py
+++ b/python/lib/scheduler/dmod/scheduler/__init__.py
@@ -1,5 +1,6 @@
 from .rsa_key_pair import RsaKeyPair
 from .ssh_key_util import SshKeyUtil, SshKeyUtilImpl
 from .utils import *
-
+from .scheduler import Launcher
+from .resources import RedisManager, Resource
 name = 'scheduler'

--- a/python/services/schedulerservice/dmod/schedulerservice/__main__.py
+++ b/python/services/schedulerservice/dmod/schedulerservice/__main__.py
@@ -4,7 +4,7 @@ from os import getenv
 from pathlib import Path
 from . import name as package_name
 from .service import SchedulerHandler
-from dmod.scheduler import Launcher, RedisManager
+from dmod.scheduler import Launcher, RedisManager, Resource
 from dmod.scheduler.job import JobManagerFactory, JobManager
 
 

--- a/python/services/schedulerservice/dmod/schedulerservice/__main__.py
+++ b/python/services/schedulerservice/dmod/schedulerservice/__main__.py
@@ -49,7 +49,8 @@ def _handle_args():
 def read_resource_list(resource_file : Path):
     with open(resource_file) as file:
         resource_list = yaml.load(file, Loader=yaml.FullLoader)
-        return resource_list['resources']
+        resource_list = [ Resource.factory_init_from_dict(resource) for resource in resource_list['resources'] ]
+        return resource_list
 
 
 def _get_parsed_or_env_val(parsed_val, env_var_suffix, fallback):

--- a/python/services/schedulerservice/setup.py
+++ b/python/services/schedulerservice/setup.py
@@ -14,6 +14,6 @@ setup(
     author_email='',
     url='',
     license='',
-    install_requires=['docker', 'redis', 'Faker', 'pyyaml', 'dmod-scheduler>=0.1.1'],
+    install_requires=['docker', 'redis', 'cryptography', 'Faker', 'pyyaml', 'dmod-scheduler>=0.1.1'],
     packages=find_namespace_packages(exclude=('tests', 'test', 'deprecated', 'conf', 'schemas', 'ssl', 'src'))
 )


### PR DESCRIPTION
Various changes have broken the deployment of the scheduler service.  This PR contains fixes that get it to at least the redis connection point.

## Changes

- Add cryptography dependency to package setup.py
- Fix package imports (and exports)
- Deserialize raw resource to `Resource` objects in service `__main__.py`

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
