### PR TITLE
strip eof/eol characters from secret file, fixes #41

### DIFF
--- a/python/lib/redis/dmod/redis/redisbacked.py
+++ b/python/lib/redis/dmod/redis/redisbacked.py
@@ -150,7 +150,7 @@ class RedisBacked(ABC):
         password_filename = parent_directory + '/' + basename
         try:
             with open(password_filename, 'r') as redis_pass_secret_file:
-                content = redis_pass_secret_file.read()
+                content = redis_pass_secret_file.read().rstrip()
                 if len(content) < 1:
                     raise ValueError
                 else:


### PR DESCRIPTION
Bug fix closes #41 
## Changes

- `rstrip()` the content read from secret file to remove eol/eof markers
