### PR TITLE
Make Action venv cache key depend on dependencies.

### DIFF
--- a/.github/workflows/testing_and_validation.yml
+++ b/.github/workflows/testing_and_validation.yml
@@ -56,9 +56,11 @@ jobs:
           mkdir ssl
           mkdir ssl/local
           mkdir ssl/requestservice
+          mkdir ssl/requests
           mkdir ssl/scheduler
           ./scripts/gen_cert.sh -d ssl/local -email robert.bartel@noaa.gov
           cp -a ssl/local/*.pem ssl/requestservice/.
+          cp -a ssl/local/*.pem ssl/requests/.
           cp -a ssl/local/*.pem ssl/scheduler/.
 
       - name: Run Tests

--- a/.github/workflows/testing_and_validation.yml
+++ b/.github/workflows/testing_and_validation.yml
@@ -25,12 +25,15 @@ jobs:
         run: sudo apt-get install -y python3-venv
         timeout-minutes: 5
 
+      - name: Prepare Contextual Dependency Hash Key
+        run: find python -name setup.py -print0 | sort -z | xargs -0 -I {} md5sum {} > context_hashes_setup_py.txt
+
       - name: Cache Python Venv
         id: cache-python-venv
         uses: actions/cache@v1
         with:
           path: dmod_venv
-          key: dmod-venv-dir
+          key: dmod-venv-dir-${{ hashFiles('context_hashes_setup_py.txt') }}
 
       - name: Init Python Venv
         if: steps.cache-python-venv.outputs.cache-hit != 'true'

--- a/.github/workflows/testing_and_validation.yml
+++ b/.github/workflows/testing_and_validation.yml
@@ -25,15 +25,12 @@ jobs:
         run: sudo apt-get install -y python3-venv
         timeout-minutes: 5
 
-      - name: Prepare Contextual Dependency Hash Key
-        run: find python -name setup.py -print0 | sort -z | xargs -0 -I {} md5sum {} > context_hashes_setup_py.txt
-
       - name: Cache Python Venv
         id: cache-python-venv
         uses: actions/cache@v1
         with:
           path: dmod_venv
-          key: dmod-venv-dir-${{ hashFiles('context_hashes_setup_py.txt') }}
+          key: dmod-venv-dir-${{ hashFiles('python/**/_version.py', '**/requirements*.txt') }}
 
       - name: Init Python Venv
         if: steps.cache-python-venv.outputs.cache-hit != 'true'

--- a/.github/workflows/testing_and_validation.yml
+++ b/.github/workflows/testing_and_validation.yml
@@ -41,6 +41,44 @@ jobs:
           deactivate 
           ./scripts/update_package.sh --venv dmod_venv -d
 
+      - name: Cache Package Checksums
+        id: cache-packages-md5
+        uses: actions/cache@v1
+        with:
+          path: package_md5s
+          key: package_md5s-${{ hashFiles('python/**/*') }}
+
+      - name: Update Individual Packages
+        id: update-individual-packages
+        run: |
+          [ ! -d package_md5s ] && mkdir package_md5s
+          set -e
+          for p in `./scripts/run_tests.sh --list-packages --service-packages --quiet`; do
+            _P_SIMPLE_NAME="`basename ${p}`"
+            _P_MD5_FILE="package_md5s/${_P_SIMPLE_NAME}.md5"
+            _P_EXPECTED_MD5="`find ${p} -type f -exec md5sum {} \; | sort -k 2 | md5sum`"
+            if [ -e ${p}/setup.py ]; then
+              if [ '${{ steps.cache-python-venv.outputs.cache-hit }}' = 'true' ]; then
+                if [ -e ${_P_MD5_FILE} ]; then
+                  if [ "`cat ${_P_MD5_FILE}`" = "${_P_EXPECTED_MD5}" ]; then
+                    echo "Package checksum file '${_P_MD5_FILE}' matches expected"
+                  else
+                    echo "Package checksum file '${_P_MD5_FILE}' contents do not match; updating"
+                    ./scripts/update_package.sh --venv dmod_venv ${p}
+                    echo "${_P_EXPECTED_MD5}" > ${_P_MD5_FILE}
+                  fi
+                else
+                  echo "Creating package checksum file '${_P_MD5_FILE}'"
+                  echo "${_P_EXPECTED_MD5}" > ${_P_MD5_FILE}
+                fi
+              else
+                echo "Creating package checksum file '${_P_MD5_FILE}'"
+                echo "${_P_EXPECTED_MD5}" > ${_P_MD5_FILE}
+              fi
+            fi
+          done
+          set +e
+
       - name: Cache SSL Setup
         id: cache-ssl-setup
         uses: actions/cache@v1

--- a/.github/workflows/testing_and_validation.yml
+++ b/.github/workflows/testing_and_validation.yml
@@ -65,7 +65,6 @@ jobs:
                   else
                     echo "Package checksum file '${_P_MD5_FILE}' contents do not match; updating"
                     ./scripts/update_package.sh --venv dmod_venv ${p}
-                    echo "${_P_EXPECTED_MD5}" > ${_P_MD5_FILE}
                   fi
                 else
                   echo "Creating package checksum file '${_P_MD5_FILE}'"


### PR DESCRIPTION
Adjusting the cache key for potentially loading the Python virtual environment during Github Action for testing and validation, such that the key is deterministically based on setup.py files for contained Python packages, thereby ensuring the cache is not used if any dependencies changed.

This should address #49.  PR #50 was also intended to help, and while it has other benefits and should continue being reviewed, I think this is a better solution to the immediate problem (assuming it works; can't really test it until something fires the Action off).
