### PR TITLE
Docker updates

### DIFF
--- a/docker/main/docker-build.yml
+++ b/docker/main/docker-build.yml
@@ -25,7 +25,7 @@ services:
     #depends_on:
     #  - base
   nwm:
-    image: ${DOCKER_INTERNAL_REGISTRY:?}/nwm-${NWM_NAME:-master}
+    image: ${DOCKER_INTERNAL_REGISTRY:?}/nwm:${NWM_VERSION:-latest}
     build:
       context: ./nwm
       args:
@@ -45,7 +45,7 @@ services:
       - base
 
   ngen:
-    image: ${DOCKER_INTERNAL_REGISTRY:?}/ngen-${NGEN_NAME:-master}
+    image: ${DOCKER_INTERNAL_REGISTRY:?}/ngen:${NGEN_VERSION:-latest}
     build:
       context: ./ngen
       args:

--- a/docker/main/docker-deploy.yml
+++ b/docker/main/docker-deploy.yml
@@ -10,7 +10,6 @@ services:
         - "3013:3013"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ../../${DOCKER_VOL_DOMAINS?}:/nwm/domains
       - ../../ssl:/ssl
       - ./schedulerservice/resources.yaml:/code/resources.yaml
       - ./schedulerservice/image_and_domain.yaml:/code/image_and_domain.yaml

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -38,5 +38,9 @@ USER root
 RUN rm -rf ${BOOST_ROOT}
 RUN echo "export PATH=${PATH}" >> /etc/profile
 USER ${USER}
-COPY entrypoint.sh ${WORKDIR}
+COPY --chown=${USER} entrypoint.sh ${WORKDIR}
+RUN chmod +x ${WORKDIR}/entrypoint.sh
 WORKDIR ${WORKDIR}
+ENV PATH=${WORKDIR}:$PATH
+ENTRYPOINT ["entrypoint.sh"]
+CMD [""]

--- a/docker/main/ngen/entrypoint.sh
+++ b/docker/main/ngen/entrypoint.sh
@@ -1,19 +1,27 @@
 #!/bin/sh
+# $1 will have the number of nodes associated with this run
+# $2 will have the host string in MPI form, i.e. hostname:N, hostname:M
+# $3 will have the unique job id
 
-# Wait a bit to make sure all service workers are up
-sleep 15
-
-req_id = $1
-echo ${req_id}
-
+#Make sure we are in workdir
 cd ${WORKDIR}
-domain_location=${WORKDIR}
-tmp_domain=${WORKDIR}/data/tmp_${req_id}
+#This is the input location that image_and_domain.yaml specificies as the run time mount location
+domain_location=/ngen/data
+#This is the output location that image_and_domain.yaml specifices as the run time mount location
+output_dir=/ngen/output
+#Create a tmp dir based on the job id to dump output to
+tmp_domain=$output_dir/tmp_$3
 mkdir -p $tmp_domain
-ln -s $domain_location/data/$2/* $tmp_domain/
-
+#Soft link the mounted static inputs
+ln -s $domain_location $tmp_domain/
+#cd to the tmp dir to run
 cd $tmp_domain
-
-ngen ./data/$1/catchment_data.geojson "" ./data/$1/nexus_data.geojson "" ./data/$1/realization_config.json
-
-echo 'ngen returned with a return value: ' $?
+#Execute the model on the linked data
+ngen ./data/catchment_data.geojson "" ./data/nexus_data.geojson "" ./data/refactored_example_realization_config.json > std_out.log 2> std_err.log
+#Capture the return value to use as service exit code
+ngen_return=$?
+echo 'ngen returned with a return value: ' $ngen_return
+#Remove soft link, which will have the same name as the last element of domain_location path
+unlink data
+#Exit with the model's exit code
+exit $ngen_return

--- a/docker/main/nwm/Dockerfile
+++ b/docker/main/nwm/Dockerfile
@@ -24,5 +24,9 @@ RUN echo "export PATH=${PATH}" >> /etc/profile
 #RUN apk add elfutils-libelf --repository http://dl-cdn.alpinelinux.org/alpine/edge/main
 #RUN apk add --update perf --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
 USER ${USER}
-COPY run_model.sh /${WORKDIR}/
+COPY --chown=${USER} run_model.sh ${WORKDIR}
+RUN chmod +x ${WORKDIR}/run_model.sh
+ENV PATH=${WORKDIR}:$PATH
 WORKDIR ${WORKDIR}/domains
+ENTRYPOINT ["run_model.sh"]
+CMD [""]

--- a/docker/main/nwm/Dockerfile
+++ b/docker/main/nwm/Dockerfile
@@ -17,7 +17,11 @@ RUN git clone --single-branch --branch $BRANCH $REPO_URL && \
     if [ "x$COMMIT" != "x" ]; then git checkout $COMMIT; fi && \
     #git checkout 6fe9fa3 && \
     ./configure 2 && \
-    ./compile_offline_NoahMP.sh ./template/setEnvar.sh
+    ./compile_offline_NoahMP.sh ./template/setEnvar.sh && \
+    mv Run/* ${WORKDIR} && \
+    cd ${WORKDIR} && \
+    rm -rf wrf_hydro_nwm_public
+
 USER root
 RUN echo "export PATH=${PATH}" >> /etc/profile
 #Tried getting some low lever profiling tools into the containers, but the sys calls are black listed.

--- a/docker/main/schedulerservice/image_and_domain.yaml
+++ b/docker/main/schedulerservice/image_and_domain.yaml
@@ -1,7 +1,7 @@
 nwm:
   version:
-    2: '127.0.0.1:5000/nwm-2.0:latest'
-    master: '127.0.0.1:5000/nwm-master'
+    2: '127.0.0.1:5000/nwm:2.0'
+    latest: '127.0.0.1:5000/nwm:latest'
     reservoir: '127.0.0.1:5000/nwm-conus-reservoir'
   domains:
     croton_NY:


### PR DESCRIPTION
Updates to the build and runtime of model images.

Key changes in the compose build steps better align model version/naming with docker version tag semantics.

The entry points of the model images needed to be in `[]` form along with `CMD []` to allow the entrypoint to be executed when the service is created and the args passed correctly to the entrypoint.

The NWM entrypoint was shored up against some particular issues involving a race condition with the SSH daemon being started vs the ssh service ready to respond to requests on the ssh port.
