### PR TITLE
Bug Fix for create_service arg

### DIFF
--- a/python/lib/scheduler/dmod/scheduler/scheduler.py
+++ b/python/lib/scheduler/dmod/scheduler/scheduler.py
@@ -299,7 +299,7 @@ class Launcher:
                    "com.docker.stack.namespace": model
                    }
         #First arg, number of "nodes"
-        args = [len(job.allocations)]
+        args = [str( len(job.allocations) )]
         #Second arg, host string
         args.append( self.build_host_list(name, job) )
         #third arg, job id


### PR DESCRIPTION
Quick bug fix that should have gone into #53 but got missed.
Essentially, need to ensure all args passed to `create_service`, and subsequently to the created docker service, are strings so they can be properly marshalled to a Go struct.