### PR TITLE
Hydrofabric selection upgrade

### DIFF
--- a/docker/nwm_gui/docker-compose.yml
+++ b/docker/nwm_gui/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     # Link everything within the static volume to /usr/maas_portal/static within the container -
     # this will help share resources
     volumes:
-      - static_volume:/usr/maas_portal/static
+      - ${DMOD_APP_STATIC:?}:/usr/maas_portal/static
       - ${DOCKER_GUI_WEB_SERVER_CONFIG_FILE:-/docker/nwm_gui/web_server/nginx/default.conf}:/etc/nginx/conf.d/default.conf
     # Make this container depend on the container holding the application server
     # TODO: this appears to break things now for some reason, despite documentation suggesting it is still supported
@@ -47,7 +47,7 @@ services:
       - MAAS_ENDPOINT_PORT=${DOCKER_REQUESTS_HOST_PORT:-3012}
       - MAAS_PORTAL_DEBUG=${DOCKER_GUI_MAAS_PORTAL_DEBUG:-true}
     volumes:
-      - static_volume:/usr/maas_portal/static
+      - ${DMOD_APP_STATIC:?}:/usr/maas_portal/static
       #- ../../gui:/usr/maas_portal
       - ${DMOD_SSL_DIR}/requestsservice:/usr/maas_portal/ssl
       #- ${DOCKER_GUI_HOST_VENV_DIR:-/tmp/blah}:${DOCKER_GUI_CONTAINER_VENV_DIR:-/tmp/blah}
@@ -66,5 +66,5 @@ networks:
     name: ${DOCKER_REQUESTS_NET_NAME}
 
 # Define persistent volumes that may be shared and persisted between containers
-volumes:
-  static_volume:
+#volumes:
+#    static_volume:

--- a/example.env
+++ b/example.env
@@ -284,3 +284,8 @@ DOCKER_REDIS_SERVICE_ALIAS=redis
 ## Directory containing scheduler resource and configuration informating, namely
 ## image_and_domain.ymal and resources.yaml
 #SCHEDULER_RESOURCE_DIR=
+
+## Directory containing static DMOD data that the GUI needs to be able to access,
+## for example, ngen hydrofabrics
+## This volume will also be used for the django app and web server to store all static assests to serve
+#DMOD_APP_STATIC=

--- a/python/gui/MaaS/static/common/css/base.css
+++ b/python/gui/MaaS/static/common/css/base.css
@@ -18,7 +18,7 @@ body {
     margin: 0;
     background-color: #ececec;
     font-family: sans-serif;
-    overflow-y: hidden;
+    overflow-y: auto;
 }
 
 #base-content-wrapper {

--- a/python/gui/MaaS/static/common/js/map.js
+++ b/python/gui/MaaS/static/common/js/map.js
@@ -379,8 +379,31 @@ function loadFabricNames() {
     );
 }
 
+function loadFabricTypes() {
+    $.ajax(
+        {
+            url: "fabric/types",
+            type: 'GET',
+            error: function(xhr,status,error) {
+                console.error(error);
+            },
+            success: function(result,status,xhr) {
+                if (result != null) {
+                    result['fabric_types'].forEach(function(name) {
+                        $("#fabric-type-selector").append("<option value='" + name + "'>" + titleCase(name) + "</option>");
+                    });
+                    $("#fabric-type-selector option")[0].setAttribute("selected", "");
+                    loadFabric();
+                }
+            }
+        }
+    );
+}
+
 function loadFabric(event) {
     var name = $("#fabric-selector").val();
+    var type = $("#fabric-type-selector").val();
+
     $("input[name=fabric]").val(name);
 
     var addTooltip = function(feature, layer) {
@@ -413,17 +436,17 @@ function loadFabric(event) {
 
         mymap.fitBounds(activeLayer.getBounds());
     }
-
-    if (name && (name != activeLayerName || activeLayer == null)) {
-        activeLayerName = name;
+    var name_type = name+"|"+type;
+    if (name && type &&  (name_type != activeLayerName || activeLayer == null)) {
+        activeLayerName = name_type;
 
         if (activeLayer) {
             Object.values(selectedLayers).forEach(layer => removeFeature(layer.feature.id));
             activeLayer.remove();
         }
 
-        if (name in loadedLayers) {
-            addDocument(loadedLayers[name]);
+        if (name_type in loadedLayers) {
+            addDocument(loadedLayers[name_type]);
         }
         else {
             var url = "fabric/" + name;
@@ -431,12 +454,13 @@ function loadFabric(event) {
                 {
                     url: url,
                     type: "GET",
+                    data: {"fabric_type":type},
                     error: function(xhr, status, error) {
                         console.error(error);
                     },
                     success: function(result, status, xhr) {
                         if (result) {
-                            loadedLayers[name] = result;
+                            loadedLayers[name_type] = result;
                             addDocument(result);
                         }
                     }

--- a/python/gui/MaaS/templates/maas/map.html
+++ b/python/gui/MaaS/templates/maas/map.html
@@ -66,6 +66,7 @@
     <fieldset id="fabric-fields" style="width: fit-content">
         <legend>Fabric</legend>
         <select id="fabric-selector" onchange="loadFabric()"></select>
+        <select id="fabric-type-selector" onchange="loadFabric()"></select>
     </fieldset>
     <div id="mapid" style="width: {{ map_width|default:'95vw' }}; height: {{ map_height|default:'70vh' }}; margin: auto"></div>
 </div>
@@ -94,6 +95,7 @@
     );
 
     startup_scripts.push(loadFabricNames);
+    startup_scripts.push(loadFabricTypes);
     startup_scripts.push(loadFabric);
 </script>
 

--- a/python/gui/MaaS/urls.py
+++ b/python/gui/MaaS/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
 from .cbv.EditView import EditView
-from .cbv.MapView import MapView, Fabrics, FabricNames, ConnectedFeatures
+from .cbv.MapView import MapView, Fabrics, FabricNames, FabricTypes, ConnectedFeatures
 
 from .cbv.configuration import CreateConfiguration
 from .cbv.execution import Execute
@@ -12,7 +12,8 @@ urlpatterns = [
     url(r'map$', MapView.as_view(), name="map"),
     url(r'map/connections$', ConnectedFeatures.as_view(), name="connections"),
     url(r'fabric/names$', FabricNames.as_view(), name='fabric-names'),
-    url(r'fabric/(?P<fabric>[a-zA-Z0-9_-]+)?', Fabrics.as_view(), name='fabrics'),
+    url(r'fabric/types$', FabricTypes.as_view(), name='fabric-types'),
+    url(r'fabric/(?P<fabric>[a-zA-Z0-9_-]+(\s\([a-zA-Z0-9_-]+\))*)?', Fabrics.as_view(), name='fabrics'),
     url(r'config/edit', CreateConfiguration.as_view(), name='create_config'),
     url(r'config/execute', Execute.as_view(), name='execute')
 ]


### PR DESCRIPTION
This PR allows a set of static, pre-defined hydrofabrics to be selected and displayed on the map for configuration selection.

## Additions

- FabricType API view

## Removals

-

## Changes

- FabricNames apiview
- Fabric view

## Testing

1. Deployed and tested config and gui changes

## Todos

- Probably worth adding some "select all" capability to configure a pre-defined hydrofabric as a whole.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Browser
