### PR TITLE
Fix temporary config collisions in stack deployment

### DIFF
--- a/scripts/control_stack.sh
+++ b/scripts/control_stack.sh
@@ -274,7 +274,7 @@ exec_requested_actions()
 
     if [ -n "${DO_DEPLOY_ACTION:-}" ]; then
         echo "Deploying stack ${STACK_NAME:?}"
-        docker_dev_deploy_stack_from_compose_using_env "${DOCKER_DEPLOY_CONFIG:?}" "${STACK_NAME:?}"
+        docker_dev_deploy_stack_from_compose_using_env "${DOCKER_DEPLOY_CONFIG:?}" "${STACK_NAME:?}" "$(whoami)"
         bail_if_action_failed $? deploy
     fi
 }

--- a/scripts/shared/docker_dev_func.sh
+++ b/scripts/shared/docker_dev_func.sh
@@ -81,11 +81,14 @@ docker_dev_build_stack_images()
 
 # Work-around to use the .env file loading for compose files when deploying with docker stack (which doesn't by itself)
 # See: https://github.com/moby/moby/issues/29133
+# arg 1 - the base config file
+# arg 2 - the stack name
+# arg 3 - some unique identifier (e.g., a user name) to add to the file name to avoid collisions
 docker_dev_deploy_stack_from_compose_using_env()
 {
     if docker-compose -f "${1:?}" config > /dev/null 2>&1; then
-        docker-compose -f "${1}" config > "/tmp/${2:?}_docker_compose_var_sub.yml" 2>/dev/null
-        docker stack deploy --compose-file "/tmp/${2}_docker_compose_var_sub.yml" "${2}"
+        docker-compose -f "${1}" config > "/tmp/${3:?}_${2:?}_docker_compose_var_sub.yml" 2>/dev/null
+        docker stack deploy --compose-file "/tmp/${3}_${2}_docker_compose_var_sub.yml" "${2}"
         return $?
     else
         echo "Error: invalid docker-compose file '${1}'; cannot start stack; exiting"


### PR DESCRIPTION
Fixing issue in helper scripts for controlling Docker stack, where it was possible, especially for different users on a shared system, to attempt to use the same filename for a required temporary config file, which would cause an error.

This is address by updating the functions involve to use a third param/arg representing a simple unique id (e.g., username), and having the constructed file name for the temporary config file to include this id.
