### PR TITLE
Update Documentation On Subsetting CLI Tool

### DIFF
--- a/doc/SUBSETTING_CLI_TOOL.md
+++ b/doc/SUBSETTING_CLI_TOOL.md
@@ -44,6 +44,7 @@ python -m venv venv         # or 'python3' if appropriate
 source venv/bin/activate    # enter the venv in this terminal
 pip install --upgrade pip
 pip install -r requirements.txt
+./scripts/update_package.sh python/lib/communication
 ./scripts/update_package.sh python/lib/modeldata
 ./scripts/update_package.sh python/services/subsetservice
 deactivate                  # exit the venv in this terminal


### PR DESCRIPTION
As noted on #95, the tutorial on [the DMOD Subsetting CLI Tool](https://github.com/NOAA-OWP/DMOD/blob/master/doc/SUBSETTING_CLI_TOOL.md) had example steps that were incomplete if starting in a fresh Python environment.  This adds another step that allows for the tutorial to be successfully run.

This closes #95.