### PR TITLE
Stack registry prefix

### DIFF
--- a/docker/main/docker-build.yml
+++ b/docker/main/docker-build.yml
@@ -20,6 +20,7 @@ services:
       context: ./schedulerservice
       args:
         docker_internal_registry: ${DOCKER_INTERNAL_REGISTRY}
+        stack_name: ${STACK_PREFIX:-}
         comms_package_name: ${PYTHON_PACKAGE_DIST_NAME_COMMS:?}
         scheduler_package_dist_name: ${PYTHON_PACKAGE_DIST_NAME_SCHEDULER:?}
         scheduler_service_package_dist_name: ${PYTHON_PACKAGE_DIST_NAME_SCHEDULER_SERVICE:?}
@@ -66,6 +67,7 @@ services:
       context: ./requestservice
       args:
         docker_internal_registry: ${DOCKER_INTERNAL_REGISTRY}
+        stack_name: ${STACK_PREFIX:-}
         comms_package_name: ${PYTHON_PACKAGE_DIST_NAME_COMMS:?}
         access_package_name: ${PYTHON_PACKAGE_DIST_NAME_ACCESS:?}
         externalrequests_package_name: ${PYTHON_PACKAGE_DIST_NAME_EXTERNAL_REQUESTS:?}
@@ -76,6 +78,7 @@ services:
       context: ./subsetservice
       args:
         docker_internal_registry: ${DOCKER_INTERNAL_REGISTRY}
+        stack_name: ${STACK_PREFIX:-}
         comms_package_name: ${PYTHON_PACKAGE_DIST_NAME_COMMS:?}
         modeldata_package_name: ${PYTHON_PACKAGE_DIST_NAME_MODELDATA:?}
         subsetservice_package_name: ${PYTHON_PACKAGE_DIST_NAME_SUBSET_SERVICE:?}

--- a/docker/main/requestservice/Dockerfile
+++ b/docker/main/requestservice/Dockerfile
@@ -1,7 +1,8 @@
 # problem using the current registry (127.0.0.1:5000), apparently due to the ':'
 # which Docker thinks is an invalid --from value in the multi-stage copy step
 ARG docker_internal_registry
-FROM ${docker_internal_registry}/dmod-py-sources as sources
+ARG stack_name
+FROM ${docker_internal_registry}/${stack_name}_dmod-py-sources as sources
 
 FROM python:3.8-alpine
 ARG comms_package_name

--- a/docker/main/schedulerservice/Dockerfile
+++ b/docker/main/schedulerservice/Dockerfile
@@ -1,7 +1,8 @@
 # problem using the current registry (127.0.0.1:5000), apparently due to the ':'
 # which Docker thinks is an invalid --from value in the multi-stage copy step
 ARG docker_internal_registry
-FROM ${docker_internal_registry}/dmod-py-sources as sources
+ARG stack_name
+FROM ${docker_internal_registry}/${stack_name}_dmod-py-sources as sources
 
 FROM python:3.8-alpine
 ARG comms_package_name

--- a/docker/main/subsetservice/Dockerfile
+++ b/docker/main/subsetservice/Dockerfile
@@ -1,7 +1,8 @@
 # problem using the current registry (127.0.0.1:5000), apparently due to the ':'
 # which Docker thinks is an invalid --from value in the multi-stage copy step
 ARG docker_internal_registry
-FROM ${docker_internal_registry}/dmod-py-sources as sources
+ARG stack_name
+FROM ${docker_internal_registry}/${stack_name}_dmod-py-sources as sources
 
 # Need to use base, rather than -alpine, image variant, due to C++ lib
 # dependencies related to pandas when using the monitordata package.

--- a/docker/nwm_gui/app_server/Dockerfile
+++ b/docker/nwm_gui/app_server/Dockerfile
@@ -2,7 +2,8 @@
 # problem using the current registry (127.0.0.1:5000), apparently due to the ':'
 # which Docker thinks is an invalid --from value in the multi-stage copy step
 ARG docker_internal_registry
-FROM ${docker_internal_registry}/dmod-py-sources as sources
+ARG stack_name
+FROM ${docker_internal_registry}/${stack_name}_dmod-py-sources as sources
 
 FROM python:3.8-slim
 # Slurp (or set default) wheel package name ...

--- a/docker/nwm_gui/docker-compose.yml
+++ b/docker/nwm_gui/docker-compose.yml
@@ -27,7 +27,7 @@ services:
   
   # Define a container belonging exclusively to our django application
   app_server:
-    image: maas-portal-development
+    image: ${STACK_PREFIX:-}_maas-portal-development
     build:
       context: ../..
       dockerfile: ./docker/nwm_gui/app_server/Dockerfile
@@ -53,7 +53,7 @@ services:
       - SQL_ENGINE=django.db.backends.postgresql
       - SQL_DATABASE=${DMOD_GUI_POSTGRES_DB:-dmod_dev}
       - SQL_USER=${DMOD_GUI_POSTGRES_USER:?}
-      - SQL_HOST=db
+      - SQL_HOST=${STACK_PREFIX:-}_nwm_gui_db
       - SQL_PORT=5432
       - DATABASE=postgres
       - DOCKER_SECRET_POSTGRES_PASS=postgres_password

--- a/docker/nwm_gui/docker-compose.yml
+++ b/docker/nwm_gui/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       args:
         docker_internal_registry: ${DOCKER_INTERNAL_REGISTRY:?Missing DOCKER_INTERNAL_REGISTRY value (see 'Private Docker Registry ' section in example.env)}
         comms_package_name: ${PYTHON_PACKAGE_DIST_NAME_COMMS:?}
+        stack_name: ${STACK_PREFIX:-}
     networks:
       - request-listener-net
     # Call this when starting the container

--- a/docker/py-sources/docker-build.yml
+++ b/docker/py-sources/docker-build.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   py-sources:
-    image: ${DOCKER_INTERNAL_REGISTRY:?Missing DOCKER_INTERNAL_REGISTRY value (see 'Private Docker Registry ' section in example.env)}/dmod-py-sources
+    image: ${DOCKER_INTERNAL_REGISTRY:?Missing DOCKER_INTERNAL_REGISTRY value (see 'Private Docker Registry ' section in example.env)}/${STACK_PREFIX:-}_dmod-py-sources
     build:
       context: ../../
       dockerfile: ./docker/py-sources/py-sources.Dockerfile


### PR DESCRIPTION
Push the stack prefix into more components for more flexibility of deployment of DMOD instances in the same environment.

## Changes

- Push the stack prefix as a build arg to allow independent development docker registries
- use the stack prefix to launch independent GUI app servers

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

### Target Environment support

- [x] Docker/Compose
