### PR TITLE
Adjust GUI requirement for requests package to fix urllib3 issue

### DIFF
--- a/python/gui/requirements.txt
+++ b/python/gui/requirements.txt
@@ -7,7 +7,7 @@ idna==2.8
 jsonschema==3.0.2
 pyrsistent==0.15.4
 pytz==2019.2
-requests==2.22.0
+requests
 six==1.12.0
 sqlparse==0.3.0
 urllib3==1.26.5


### PR DESCRIPTION
Loosening restriction of specific version for requests package as part
of the requirements for the GUI Python code, as the previous version was
causing a dependency conflict after the move to urllib3 1.26.5 (closes
#105).
