### PR TITLE
Update ngen and ngen-deps Docker images

### DIFF
--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -12,27 +12,73 @@ ARG BRANCH=master
 ARG COMMIT
 ARG BUILD_PARALLEL_JOBS
 ENV PATH "${WORKDIR}/bin:${PATH}"
-ARG BOOST_VERSION=1.72.0
 ENV BOOST_ROOT=${WORKDIR}/boost
 
-#RUN wget https://dl.bintray.com/boostorg/release/${BOOST_VERSION}/source/boost_${BOOST_VERSION//./_}.tar.gz \
-RUN wget https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//./_}.tar.gz/download -O boost_${BOOST_VERSION//./_}.tar.gz \
-#### \
-    # Get boost headers \
-    #### \
-    && mkdir -p ${WORKDIR}/boost \
-    && tar zxf boost_${BOOST_VERSION//./_}.tar.gz -C ./boost --strip-components=1 \
-    && rm boost_${BOOST_VERSION//./_}.tar.gz \
-    && git clone --single-branch --branch $BRANCH $REPO_URL \
+ARG NGEN_ACTIVATE_C="ON"
+ARG NGEN_ACTIVATE_FORTRAN="ON"
+ARG NGEN_ACTIVATE_PYTHON="ON"
+ARG NGEN_MPI_ACTIVE="ON"
+ARG NGEN_ROUTING_ACTIVE="ON"
+ARG NGEN_UDUNITS_ACTIVE="ON"
+
+ARG BUILD_NOAH_OWP="true"
+ARG BUILD_CFE="true"
+ARG BUILD_TOPMODEL="true"
+
+# TODO: add something to build to pull (and build) in the submodules (except googletest) when needed based on build config
+
+# Swap or override this as needed (below are the "standard" types from
+#   https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#default-and-custom-configurations)
+#ARG NGEN_BUILD_CONFIG_TYPE="Debug"
+ARG NGEN_BUILD_CONFIG_TYPE="Release"
+#ARG NGEN_BUILD_CONFIG_TYPE="RelWithDebInfo"
+#ARG NGEN_BUILD_CONFIG_TYPE="MinSizeRel"
+
+RUN git clone --single-branch --branch $BRANCH $REPO_URL \
     && cd ./ngen \
-    && git submodule update --init --recursive -- test/googletest \
     && if [ "x$COMMIT" != "x" ]; then git checkout $COMMIT; fi \
-    && cmake -B cmake-build -S . -DCMAKE_INSTALL_PREFIX=${WORKDIR} \
-    && cmake --build cmake-build -j ${BUILD_PARALLEL_JOBS} \
+    && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then pip install -r extern/test_bmi_py/requirements.txt; fi \
+    && git submodule update --init test/googletest \
+    && git submodule update --init \
+    && echo "#!/bin/bash" > build_sub \
+    && echo "cmake -B \$1/cmake_build -DCMAKE_BUILD_TYPE=${NGEN_BUILD_CONFIG_TYPE} -S \$1 && cmake --build \$1/cmake_build" >> build_sub \
+    && chmod u+x build_sub \
+    &&  if [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ]; then \
+            ./build_sub extern/iso_c_fortran_bmi; \
+            if [ "${BUILD_NOAH_OWP}" == "true" ] ; then ./build_sub extern/noah-mp-modular; fi; \
+        fi \
+    &&  if [ "${NGEN_ACTIVATE_C}" == "ON" ]; then \
+            if [ "${BUILD_CFE}" == "true" ] ; then ./build_sub extern/cfe; fi; \
+            if [ "${BUILD_TOPMODEL}" == "true" ] ; then ./build_sub extern/topmodel; fi; \
+        fi \
+    && cmake -B cmake_build -S . \
+            -DMPI_ACTIVE:BOOL=${NGEN_MPI_ACTIVE} \
+            -DBMI_C_LIB_ACTIVE:BOOL=${NGEN_ACTIVATE_C} \
+            -DBMI_FORTRAN_ACTIVE:BOOL=${NGEN_ACTIVATE_FORTRAN} \
+            -DNGEN_ACTIVATE_PYTHON:BOOL=${NGEN_ACTIVATE_PYTHON} \
+            -DNGEN_ACTIVATE_ROUTING:BOOL=${NGEN_ROUTING_ACTIVE} \
+            -DUDUNITS_ACTIVE:BOOL=${NGEN_UDUNITS_ACTIVE} \
+            -DCMAKE_INSTALL_PREFIX=${WORKDIR} \
+    && cmake --build cmake_build -j ${BUILD_PARALLEL_JOBS} \
     #Run the tests, if they fail, the image build fails \
-    && cmake-build/test/test_all \
+    && cmake_build/test/test_unit \
+    &&  if [ "${NGEN_ACTIVATE_C}" == "ON" ]; then \
+            ./build_sub extern/test_bmi_c; \
+            cmake_build/test/test_bmi_c; \
+        fi \
+    &&  if [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ]; then \
+            ./build_sub extern/test_bmi_fortran; \
+            cmake_build/test/test_bmi_fortran; \
+        fi \
+    &&  if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
+            ./build_sub extern/test_bmi_py; \
+            cmake_build/test/test_bmi_python; \
+        fi \
+    &&  if [ "${NGEN_ACTIVATE_C}" == "ON" ] && [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ] && [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
+            cmake_build/test/test_bmi_multi; \
+        fi \
     #FIXME remove the data copy, only there for temporary testing \
-    && mkdir ${WORKDIR}/bin && cp cmake-build/ngen ${WORKDIR}/bin && cp -r data ${WORKDIR}/data \
+    && mkdir ${WORKDIR}/bin && cp cmake_build/ngen ${WORKDIR}/bin && cp -r data ${WORKDIR}/data \
     && cd $WORKDIR && rm -rf ngen boost
 
 USER root

--- a/docker/main/ngen/deps/Dockerfile
+++ b/docker/main/ngen/deps/Dockerfile
@@ -1,65 +1,118 @@
 ARG DOCKER_INTERNAL_REGISTRY
-FROM ${DOCKER_INTERNAL_REGISTRY}/nwm-base
+ARG BOOST_VERSION=1.72.0
+ARG MPICH_VERSION="3.2"
+ARG MIN_PYTHON="3.8.0"
+ARG MIN_NUMPY="1.18.0"
+#ARG REPOS="http://dl-cdn.alpinelinux.org/alpine/edge/testing"
+ARG REPOS=""
+
+################################################################################################################
+FROM ${DOCKER_INTERNAL_REGISTRY}/nwm-base AS get_boost
+
+# Redeclaring inside this stage to get default from before first FROM
+ARG BOOST_VERSION
 
 USER root
 
-########################################
-# Model specific ENV
-########################################
+RUN wget https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//./_}.tar.bz2/download -O boost_${BOOST_VERSION//./_}.tar.bz2 \
+    && mkdir /boost \
+    && mv boost_${BOOST_VERSION//./_}.tar.bz2 /boost/. \
+    && cd /boost \
+    && tar -xjf boost_${BOOST_VERSION//./_}.tar.bz2 \
+    && rm boost_${BOOST_VERSION//./_}.tar.bz2
+
+USER ${USER}
+################################################################################################################
+FROM ${DOCKER_INTERNAL_REGISTRY}/nwm-base AS download_mpi
+
+# Redeclaring inside this stage to get default from before first FROM
+ARG MPICH_VERSION
+
+USER root
+
+# MPICH build and install \
+    #### \
+RUN mkdir /mpich-src \
+    && cd /mpich-src \
+    && wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz \
+    && tar xfz mpich-${MPICH_VERSION}.tar.gz \
+    && rm mpich-${MPICH_VERSION}.tar.gz
+
+USER ${USER}
+################################################################################################################
+FROM ${DOCKER_INTERNAL_REGISTRY}/nwm-base AS install_apk_deps
+USER root
+
+# Redeclaring inside this stage to get default from before first FROM
+ARG REPOS
+
+ARG MPI_REQUIRE="sudo gcc g++ musl-dev make cmake tar git"
+
+RUN apk update && apk upgrade \
+    && if [ -n "${REPOS}" ]; then \
+            apk add --repository ${REPOS} --no-cache ${MPI_REQUIRE}; \
+        else \
+            apk add --no-cache ${MPI_REQUIRE}; \
+        fi
+
+USER ${USER}
+################################################################################################################
+FROM install_apk_deps
+
+USER root
+
+# Redeclaring inside this stage to get default from before first FROM
+ARG MIN_PYTHON
+ARG MIN_NUMPY
+ARG MPICH_VERSION
+ARG REPOS
+
 ARG WORKDIR=/ngen
 ENV WORKDIR=${WORKDIR}
-#### CREATE WORKING DIRECTORY FOR MODEL #### \
-RUN mkdir ${WORKDIR} \
-    && chown -R ${USER}:${USER} ${WORKDIR} \
-    # Auto go to default working directory when user ssh login \
-    && echo "cd $WORKDIR" >> ${USER_HOME}/.profile \
-WORKDIR ${WORKDIR}
 
-########################################
-# Model specific dependencies/builds
-########################################
+ENV BOOST_ROOT=${WORKDIR}/boost
 
-#ARG REPOS="http://dl-cdn.alpinelinux.org/alpine/edge/testing"
-ARG REQUIRE="sudo gcc g++ musl-dev make cmake tar git"
-
-#Eventually, MPI probably required for ngen
 ENV HYDRA_HOST_FILE /etc/opt/hosts
-# MPICH Build Options:
+
+ARG MPICH_CONFIGURE_OPTIONS="--disable-fortran"
+ARG MPICH_MAKE_OPTIONS
+
+# Copying should also take care of creating the working dir
+COPY --from=get_boost /boost ${WORKDIR}/boost
+COPY --from=download_mpi /mpich-src ${WORKDIR}/mpich-src
+
 # See installation guide of target MPICH version
 # Ex: http://www.mpich.org/static/downloads/3.2/mpich-3.2-installguide.pdf
 # These options are passed to the steps below
-#ARG MPICH_VERSION="3.2"
-#ARG MPICH_CONFIGURE_OPTIONS="--disable-fortran"
-#ARG MPICH_MAKE_OPTIONS
 
-### INSTALL MPICH ####
-# Source is available at http://www.mpich.org/static/downloads/
-# Download, build, and install MPICH
-
-RUN apk update && apk upgrade && apk add --repository ${REPOS} --no-cache ${REQUIRE}
-    #### \
-    # MPICH build and install \
-    #### \
-#    && mkdir /tmp/mpich-src \
-#    && cd /tmp/mpich-src \
-#    && wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz \
-#    && tar xfz mpich-${MPICH_VERSION}.tar.gz  \
-#    && cd mpich-${MPICH_VERSION}  \
-#    && ./configure ${MPICH_CONFIGURE_OPTIONS}  \
-#    && make -j 8 ${MPICH_MAKE_OPTIONS} && make install \
-#    && cd /tmp \
-#    && rm -rf /tmp/mpich-src \
+#RUN mkdir ${WORKDIR}
+# Auto go to default working directory when user ssh login
+RUN echo "cd ${WORKDIR}" >> ${USER_HOME}/.profile \
+    && cd ${WORKDIR}/mpich-src/mpich-${MPICH_VERSION} \
+    && ./configure ${MPICH_CONFIGURE_OPTIONS}  \
+    && make -j $(nproc) ${MPICH_MAKE_OPTIONS} \
+    && make install \
+    && cd ${WORKDIR} \
+    && rm -rf ${WORKDIR}/mpich-src \
+    && chown -R ${USER}:${USER} ${WORKDIR} \
     #### \
     #   Configure MPI \
     #### \
     # Hostfile location for mpirun. This file will be updated automatically. \
-#    && echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
-#    && touch ${HYDRA_HOST_FILE} \
-#    && chown ${USER}:${USER} ${HYDRA_HOST_FILE} \
-#    && mkdir -p ${WORKDIR}/domains
+    && echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
+    && touch ${HYDRA_HOST_FILE} \
+    && chown ${USER}:${USER} ${HYDRA_HOST_FILE}
+    #&& mkdir -p ${WORKDIR}/domains
 
+# Handle final required dependencies separately so we don't have to, e.g., rebuild MPI if we want to update Python
+ARG REQUIRE="sudo gcc g++ musl-dev make cmake tar git gfortran libgfortran python3>=${MIN_PYTHON} python3-dev>=${MIN_PYTHON} py3-pip py3-numpy>=${MIN_NUMPY} py3-numpy-dev>=${MIN_NUMPY} netcdf netcdf-dev hdf5 hdf5-dev bzip2 texinfo expat expat-dev flex bison"
+RUN apk update && apk upgrade \
+    && if [ -n "${REPOS}" ]; then \
+            apk add --repository ${REPOS} --no-cache ${REQUIRE}; \
+        else \
+            apk add --no-cache ${REQUIRE}; \
+        fi
+
+ENV BOOST_ROOT=${WORKDIR}/boost
 USER ${USER}
-####
-#   Pull latest ngen and build
-####
 WORKDIR ${WORKDIR}


### PR DESCRIPTION
Updating the `ngen` and `ngen-deps` Docker images to be up to date with the current revision of the Nextgen framework code.

This will close #100.