### PR TITLE
Fixes and improvements to Docker stack image builds and dependencies

### DIFF
--- a/docker/main/base/Dockerfile
+++ b/docker/main/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.15
 # In case the main package repositories are down, use the alternative base image:
 # FROM gliderlabs/alpine:3.12
 

--- a/docker/main/base/Dockerfile
+++ b/docker/main/base/Dockerfile
@@ -10,7 +10,11 @@ ARG USER=mpi
 ENV USER=${USER} USER_HOME=/home/${USER}
 ENV SSHDIR=${USER_HOME}/.ssh
 RUN apk update && apk upgrade \
-    && apk add --repository ${REPOS} --no-cache ${REQUIRE} \
+    &&  if [ -n "${REPOS}" ]; then \
+            apk add --repository ${REPOS} --no-cache ${REQUIRE}; \
+        else \
+            apk add --no-cache ${REQUIRE}; \
+        fi \
     #### ADD DEFAULT USER #### \
     && adduser -D ${USER} \
     && echo "${USER}   ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \

--- a/docker/main/docker-build.yml
+++ b/docker/main/docker-build.yml
@@ -23,6 +23,7 @@ services:
         comms_package_name: ${PYTHON_PACKAGE_DIST_NAME_COMMS:?}
         scheduler_package_dist_name: ${PYTHON_PACKAGE_DIST_NAME_SCHEDULER:?}
         scheduler_service_package_dist_name: ${PYTHON_PACKAGE_DIST_NAME_SCHEDULER_SERVICE:?}
+        scheduler_service_package_version_constraint: ${PYTHON_PACKAGE_DIST_VERSION_CONSTRAINT_SCHEDULER_SERVICE:-}
     #depends_on:
     #  - base
   nwm:
@@ -70,6 +71,7 @@ services:
         access_package_name: ${PYTHON_PACKAGE_DIST_NAME_ACCESS:?}
         externalrequests_package_name: ${PYTHON_PACKAGE_DIST_NAME_EXTERNAL_REQUESTS:?}
         request_service_package_name: ${PYTHON_PACKAGE_DIST_NAME_REQUEST_SERVICE:?}
+        request_service_package_version_constraint: ${PYTHON_PACKAGE_DIST_VERSION_CONSTRAINT_REQUEST_SERVICE:-}
   subset-service:
     image: ${DOCKER_INTERNAL_REGISTRY:?}/subset-service
     build:

--- a/docker/main/ngen/deps/Dockerfile
+++ b/docker/main/ngen/deps/Dockerfile
@@ -105,7 +105,7 @@ RUN echo "cd ${WORKDIR}" >> ${USER_HOME}/.profile \
     #&& mkdir -p ${WORKDIR}/domains
 
 # Handle final required dependencies separately so we don't have to, e.g., rebuild MPI if we want to update Python
-ARG REQUIRE="sudo gcc g++ musl-dev make cmake tar git gfortran libgfortran python3>=${MIN_PYTHON} python3-dev>=${MIN_PYTHON} py3-pip py3-numpy>=${MIN_NUMPY} py3-numpy-dev>=${MIN_NUMPY} netcdf netcdf-dev hdf5 hdf5-dev bzip2 texinfo expat expat-dev flex bison"
+ARG REQUIRE="sudo gcc g++ musl-dev make cmake tar git gfortran libgfortran python3>=${MIN_PYTHON} python3-dev>=${MIN_PYTHON} py3-pip py3-numpy>=${MIN_NUMPY} py3-numpy-dev>=${MIN_NUMPY} py3-pandas netcdf netcdf-dev hdf5 hdf5-dev bzip2 texinfo expat expat-dev flex bison"
 RUN apk update && apk upgrade \
     && if [ -n "${REPOS}" ]; then \
             apk add --repository ${REPOS} --no-cache ${REQUIRE}; \

--- a/docker/main/nwm/deps/Dockerfile
+++ b/docker/main/nwm/deps/Dockerfile
@@ -26,12 +26,11 @@ ARG REPOS="http://dl-cdn.alpinelinux.org/alpine/edge/testing"
 # Building hdf5 from source for parallel support, otherwise add hdf5 hdf5-dev to the list below
 ARG REQUIRE="sudo build-base gfortran openssl curl curl-dev tar git m4 zlib-dev libexecinfo-dev"
 
-# ARG NETCDF_C_VERSION="latest"
-#ARG NETCDF_C_VERSION="v4.6.0"
-ARG NETCDF_C_VERSION
-ENV NETCDF_C_VERSION ${NETCDF_C_VERSION:-latest}
-ARG NETCDF_FORTRAN_VERSION
-ENV NETCDF_FORTRAN_VERSION ${NETCDF_FORTRAN_VERSION:-latest}
+# Due to https://github.com/NOAA-OWP/DMOD/issues/75, these NetCDF versions need to have these defaults for now
+ARG NETCDF_C_VERSION=v4.6.0
+ENV NETCDF_C_VERSION ${NETCDF_C_VERSION}
+ARG NETCDF_FORTRAN_VERSION=v4.5.2
+ENV NETCDF_FORTRAN_VERSION ${NETCDF_FORTRAN_VERSION}
 ENV HYDRA_HOST_FILE /etc/opt/hosts
 # MPICH Build Options:
 # See installation guide of target MPICH version

--- a/docker/main/nwm/deps/Dockerfile
+++ b/docker/main/nwm/deps/Dockerfile
@@ -22,7 +22,8 @@ WORKDIR ${WORKDIR}
 # Model specific dependencies/builds
 ########################################
 
-ARG REPOS="http://dl-cdn.alpinelinux.org/alpine/edge/testing"
+#ARG REPOS="http://dl-cdn.alpinelinux.org/alpine/edge/testing"
+ARG REPOS
 # Building hdf5 from source for parallel support, otherwise add hdf5 hdf5-dev to the list below
 ARG REQUIRE="sudo build-base gfortran openssl curl curl-dev tar git m4 zlib-dev libexecinfo-dev"
 
@@ -44,7 +45,12 @@ ARG MPICH_MAKE_OPTIONS
 # Source is available at http://www.mpich.org/static/downloads/
 # Download, build, and install MPICH
 
-RUN apk update && apk upgrade && apk add --repository ${REPOS} --no-cache ${REQUIRE} \
+RUN apk update && apk upgrade \
+    &&  if [ -n "${REPOS}" ]; then \
+            apk add --repository ${REPOS} --no-cache ${REQUIRE}; \
+        else  \
+            apk add --no-cache ${REQUIRE}; \
+        fi \
     && mkdir /tmp/mpich-src \
     && cd /tmp/mpich-src \
     && wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz \

--- a/docker/main/nwm/deps/Dockerfile
+++ b/docker/main/nwm/deps/Dockerfile
@@ -62,7 +62,7 @@ RUN apk update && apk upgrade \
     && export FFLAGS="${FFLAGS}" \
     && export FCFLAGS="${FCFLAGS}" \
     && ./configure ${MPICH_CONFIGURE_OPTIONS}  \
-    && make -j 8 ${MPICH_MAKE_OPTIONS} && make install \
+    && make -j $(nproc) ${MPICH_MAKE_OPTIONS} && make install \
     && cd /tmp \
     && rm -rf /tmp/mpich-src \
     #### \

--- a/docker/main/nwm/deps/Dockerfile
+++ b/docker/main/nwm/deps/Dockerfile
@@ -40,6 +40,9 @@ ENV HYDRA_HOST_FILE /etc/opt/hosts
 ARG MPICH_VERSION="3.2"
 ARG MPICH_CONFIGURE_OPTIONS=""
 ARG MPICH_MAKE_OPTIONS
+# Work around Fortran MPI issue
+ARG FCFLAGS="-w -fallow-argument-mismatch -O2"
+ARG FFLAGS="-w -fallow-argument-mismatch -O2"
 
 ### INSTALL MPICH ####
 # Source is available at http://www.mpich.org/static/downloads/
@@ -56,6 +59,8 @@ RUN apk update && apk upgrade \
     && wget http://www.mpich.org/static/downloads/${MPICH_VERSION}/mpich-${MPICH_VERSION}.tar.gz \
     && tar xfz mpich-${MPICH_VERSION}.tar.gz  \
     && cd mpich-${MPICH_VERSION}  \
+    && export FFLAGS="${FFLAGS}" \
+    && export FCFLAGS="${FCFLAGS}" \
     && ./configure ${MPICH_CONFIGURE_OPTIONS}  \
     && make -j 8 ${MPICH_MAKE_OPTIONS} && make install \
     && cd /tmp \

--- a/docker/main/requestservice/Dockerfile
+++ b/docker/main/requestservice/Dockerfile
@@ -8,6 +8,7 @@ ARG comms_package_name
 ARG access_package_name
 ARG externalrequests_package_name
 ARG request_service_package_name
+ARG request_service_package_version_constraint
 # A base SSL directory, which may or may not contain subdirectories specifically for service- or client-side certs
 ARG container_base_ssl_directory=/ssl
 
@@ -19,7 +20,9 @@ COPY ./entrypoint.sh entrypoint.sh
 COPY --from=sources /DIST /DIST
 
 # Install custom and generally available packages, starting with any custom from external source image
-RUN pip install --no-index --find-links=/DIST ${request_service_package_name} \
+# Do these separately first to work around some issues
+RUN pip install websockets Deprecated \
+    && pip install --no-index --find-links=/DIST "${request_service_package_name}${request_service_package_version_constraint}" \
     # After eventually installing all custom packages like this, clean up ... \
     && rm -r /DIST
 

--- a/docker/main/requestservice/Dockerfile
+++ b/docker/main/requestservice/Dockerfile
@@ -21,6 +21,7 @@ COPY --from=sources /DIST /DIST
 
 # Install custom and generally available packages, starting with any custom from external source image
 # Do these separately first to work around some issues
+# TODO: fix root cause for problem this works around
 RUN pip install websockets Deprecated \
     && pip install --no-index --find-links=/DIST "${request_service_package_name}${request_service_package_version_constraint}" \
     # After eventually installing all custom packages like this, clean up ... \

--- a/docker/main/schedulerservice/Dockerfile
+++ b/docker/main/schedulerservice/Dockerfile
@@ -7,6 +7,7 @@ FROM python:3.8-alpine
 ARG comms_package_name
 ARG scheduler_package_dist_name
 ARG scheduler_service_package_dist_name
+ARG scheduler_service_package_version_constraint
 
 WORKDIR /code
 
@@ -16,12 +17,12 @@ COPY ./entrypoint.sh entrypoint.sh
 COPY --from=sources /DIST /DIST
 
 RUN apk update \
-    && apk add --no-cache openssl bash \
+    && apk add --no-cache openssl bash python3-dev libffi-dev musl-dev gcc \
     && rm -rf /var/cache/apk/* \
     && alias python=python3 \
     && pip3 install --no-cache-dir --upgrade pip \
     # Install service package, along with custom and generally available dependencies, which should all be in /DIST \
-    && pip3 install --no-cache-dir --find-links=/DIST ${scheduler_service_package_dist_name} \
+    && pip3 install --no-cache-dir --find-links=/DIST "${scheduler_service_package_dist_name}${scheduler_service_package_version_constraint}" \
     # After installing everything needed from /DIST, clean up ... \
     && rm -r /DIST \
     && mkdir -p ~/.ssh \

--- a/docker/main/schedulerservice/Dockerfile
+++ b/docker/main/schedulerservice/Dockerfile
@@ -21,6 +21,9 @@ RUN apk update \
     && rm -rf /var/cache/apk/* \
     && alias python=python3 \
     && pip3 install --no-cache-dir --upgrade pip \
+    # Do websockets package separately first to work around some current issues (2/1/2022) \
+    # TODO: fix root cause for problem this works around \
+    && pip3 install websockets \
     # Install service package, along with custom and generally available dependencies, which should all be in /DIST \
     && pip3 install --no-cache-dir --find-links=/DIST "${scheduler_service_package_dist_name}${scheduler_service_package_version_constraint}" \
     # After installing everything needed from /DIST, clean up ... \

--- a/docker/main/subsetservice/Dockerfile
+++ b/docker/main/subsetservice/Dockerfile
@@ -30,7 +30,10 @@ COPY --from=sources /DIST /DIST
 
 COPY ./entrypoint.sh entrypoint.sh
 # Install custom and generally available packages, starting with any custom from external source image
-RUN pip install --no-index --find-links=/DIST ${subsetservice_package_name} \
+# Do these first packages separately first to work around some current issues (2/1/2022)
+# TODO: fix root cause for problem this works around
+RUN pip install websockets MarkupSafe yarl wrapt \
+    && pip install --no-index --find-links=/DIST ${subsetservice_package_name} \
     # After eventually installing all custom packages like this, clean up ... \
     && rm -r /DIST
 

--- a/docker/py-sources/py-sources.Dockerfile
+++ b/docker/py-sources/py-sources.Dockerfile
@@ -1,8 +1,9 @@
 ################################################################################################################
 ################################################################################################################
 ##### Create base level intermediate build stage
-FROM python:3.8-alpine as basis
-ARG REQUIRE="gcc g++ musl-dev gdal-dev libffi-dev openssl-dev rust cargo git"
+FROM python:3.8-alpine3.15 as basis
+ARG REQUIRE="gcc g++ musl-dev proj proj-dev proj-util gdal-dev libffi-dev openssl-dev rust cargo git"
+
 RUN apk update && apk upgrade && apk add --no-cache ${REQUIRE}
 # Install a few requirements that are going to be expected first, since they take a very long time
 # I.e., we prefer not to go through an hour of building/installing again whenever some other requirement changes

--- a/example.env
+++ b/example.env
@@ -84,6 +84,8 @@ PYTHON_PACKAGE_NAME_COMMS=dmod.communication
 
 ## The "name" of the built request service Python distribution package, for purposes of installing (e.g., via pip)
 PYTHON_PACKAGE_DIST_NAME_REQUEST_SERVICE=dmod-requestservice
+## Optional version constraint for the scheduler SERVICE Python distribution package (pip format)
+#PYTHON_PACKAGE_DIST_VERSION_CONSTRAINT_REQUEST_SERVICE=>=0.3.0
 ## The name of the actual Python request service package (i.e., for importing or specifying as a module on the command line)
 PYTHON_PACKAGE_NAME_REQUEST_SERVICE=dmod.requestservice
 
@@ -94,6 +96,8 @@ PYTHON_PACKAGE_NAME_SCHEDULER=dmod.scheduler
 
 ## The "name" of the built scheduler SERVICE Python distribution package, for purposes of installing (e.g., via pip)
 PYTHON_PACKAGE_DIST_NAME_SCHEDULER_SERVICE=dmod-schedulerservice
+## Optional version constraint for the scheduler SERVICE Python distribution package (pip format)
+#PYTHON_PACKAGE_DIST_VERSION_CONSTRAINT_SCHEDULER_SERVICE=>=0.3.0
 ## The name of the actual Python scheduler SERVICE package (i.e., for importing or specifying as a module on the command line)
 PYTHON_PACKAGE_NAME_SCHEDULER_SERVICE=dmod.schedulerservice
 

--- a/example.env
+++ b/example.env
@@ -84,7 +84,7 @@ PYTHON_PACKAGE_NAME_COMMS=dmod.communication
 
 ## The "name" of the built request service Python distribution package, for purposes of installing (e.g., via pip)
 PYTHON_PACKAGE_DIST_NAME_REQUEST_SERVICE=dmod-requestservice
-## Optional version constraint for the scheduler SERVICE Python distribution package (pip format)
+## Optional version constraint for the request SERVICE Python distribution package (pip format)
 #PYTHON_PACKAGE_DIST_VERSION_CONSTRAINT_REQUEST_SERVICE=>=0.3.0
 ## The name of the actual Python request service package (i.e., for importing or specifying as a module on the command line)
 PYTHON_PACKAGE_NAME_REQUEST_SERVICE=dmod.requestservice


### PR DESCRIPTION
Fixes and improvements to Docker stack image builds and dependencies.

- Add Python package version constraint to `schedulerservice` and `requestservice` Docker images
- Optimizing `py-sources` Docker image build layers for fewer long rebuilds
- Default to better versions for NetCDF packags in `nwm-deps` image
- Bump model execution `base` image to be based on alpine 3.15
- Fix `base` Docker image apk package add command
- Add `pandas` to `ngen-deps` image apk packages
- Fix `nwm-deps` image build for `apk` '--repository' use
- Fix MPI build issue in `nwm-deps` in new alpine
- Fix bug in `nwm-deps` with MPI build and job count