### PR TITLE
Initial data flow and data service pre-work

### DIFF
--- a/python/lib/modeldata/dmod/modeldata/data/__init__.py
+++ b/python/lib/modeldata/dmod/modeldata/data/__init__.py
@@ -1,3 +1,4 @@
 from .catchment_data import CatchmentData
 from .data_subset import AbstractDataSubset
 from .forcing_data_handler import ForcingDataHandler
+from .meta_data import DataRequirement, CatchmentDataRequirement, DataCategory, DataFormat

--- a/python/lib/modeldata/dmod/modeldata/data/data_subset.py
+++ b/python/lib/modeldata/dmod/modeldata/data/data_subset.py
@@ -5,7 +5,7 @@ from typing import Collection, Optional, Sequence, Tuple
 from ..subset import SimpleHydrofabricSubset
 
 
-class AbstractDataSubset(ABC, SimpleHydrofabricSubset):
+class AbstractDataSubset(SimpleHydrofabricSubset, ABC):
     """
     Extension of ::class:`HydrofabricSubset` that also encapsulates the applicable data.
     """
@@ -43,8 +43,8 @@ class AbstractDataSubset(ABC, SimpleHydrofabricSubset):
     def range_start(self) -> datetime:
         return self._range_start
 
-    @abstractmethod
     @property
+    @abstractmethod
     def storage_size(self) -> int:
         """
         Get the size of the backing data files for this data subset, if such files exist.

--- a/python/lib/modeldata/dmod/modeldata/data/meta_data.py
+++ b/python/lib/modeldata/dmod/modeldata/data/meta_data.py
@@ -1,0 +1,357 @@
+from abc import ABC, abstractmethod
+from enum import Enum
+from datetime import datetime
+from dmod.communication.serializeable import Serializable
+from numbers import Number
+from typing import Dict, Generic, Optional, Tuple, Type, TypeVar, Union
+from ..subset import SubsetDefinition
+
+DOMAIN_PARAM_TYPE = TypeVar('DOMAIN_PARAM_TYPE')
+
+
+class DataFormat(Enum):
+    AORC_CSV = (0,)
+    """ The CSV data format the Nextgen framework originally used during its early development. """
+    NETCDF_FORCING_CANONICAL = (1,)
+    """ The Nextgen framework "canonical" NetCDF forcing data format. """
+    NETCDF_AORC_DEFAULT = (2,)
+    """ The default format for "raw" AORC forcing data. """
+    # TODO: need to specify the particular data property fields for given formats
+    # TODO: need format specifically for Nextgen model output (i.e., for evaluations)
+
+    @classmethod
+    def get_for_name(cls, name_str: str) -> Optional['DataFormat']:
+        cleaned_up_str = name_str.strip().upper()
+        for value in cls:
+            if value.name.upper() == cleaned_up_str:
+                return value
+        return None
+
+    def __init__(self, uid: int, data_fields: Optional[Dict[str, Type]] = None):
+        self._uid = uid
+        self._data_fields = data_fields
+
+    @property
+    def data_fields(self) -> Optional[Dict[str, Type]]:
+        """
+        The specific data fields for this format.
+
+        Returns
+        -------
+        Optional[Dict[str, Type]]
+            The specific data fields for this format.
+        """
+        return self._data_fields
+
+
+class DataCategory(Enum):
+    """
+    The general category values for different data.
+    """
+    FORCING = 0
+    HYDROFABRIC = 1
+    OUTPUT = 2
+    OBSERVATION = 3
+
+    @classmethod
+    def get_for_name(cls, name_str: str) -> Optional['DataCategory']:
+        cleaned_up_str = name_str.strip().upper()
+        for value in cls:
+            if value.name.upper() == cleaned_up_str:
+                return value
+        return None
+
+
+class TimeRange(Serializable):
+    """
+    Encapsulated representation of a time range.
+    """
+
+    SERIAL_DATETIME_STR_FORMAT = '%Y-%m-%d %H:%M:%S'
+
+    @classmethod
+    def factory_init_from_deserialized_json(cls, json_obj: dict):
+        try:
+            return cls(range_begin=datetime.strptime(json_obj['range_begin'], cls.SERIAL_DATETIME_STR_FORMAT),
+                       range_end=datetime.strptime(json_obj['range_end'], cls.SERIAL_DATETIME_STR_FORMAT))
+        except:
+            return None
+
+    def __init__(self, range_begin: datetime, range_end: datetime):
+        self.range_begin = range_begin
+        self.range_end = range_end
+
+    def to_dict(self) -> Dict[str, Union[str, Number, dict, list]]:
+        serial = {}
+        serial['range_begin'] = self.range_begin.strftime(self.SERIAL_DATETIME_STR_FORMAT)
+        serial['range_end'] = self.range_end.strftime(self.SERIAL_DATETIME_STR_FORMAT)
+        return serial
+
+
+class DataRequirement(Serializable, ABC, Generic[DOMAIN_PARAM_TYPE]):
+    """
+    A definition of a particular data requirement needed for an execution task.
+    """
+
+    _KEY_CATEGORY = 'category'
+    """ Serialization dictionary JSON key for ::attribute:`category` property value. """
+    _KEY_DOMAIN_PARAMS = 'domain_params'
+    """ Serialization dictionary JSON key for ::attribute:`domain_params` property value. """
+    _KEY_FULFILLED_BY = 'fulfilled_by'
+    """ Serialization dictionary JSON key for ::attribute:`fulfilled_by` property value. """
+    _KEY_IS_INPUT = 'is_input'
+    """ Serialization dictionary JSON key for ::attribute:`is_input` property value. """
+    _KEY_REQ_SUBTYPE = 'requirement_type'
+    """ Serialization dictionary JSON key for field to indicate the specific subtype class that was serialized. """
+    _KEY_SIZE = 'size'
+    """ Serialization dictionary JSON key for ::attribute:`size` property value. """
+    _KEY_TIME_PARAMS = 'time_params'
+    """ Serialization dictionary JSON key for ::attribute:`time_params` property value. """
+
+    @classmethod
+    def _deserialize_common(cls, json_obj: dict) -> Tuple[
+            DataCategory, bool, Optional[TimeRange], Optional[str], Optional[int]]:
+        """
+        Deserialize a common collection of property values for various subtypes, and return in a tuple.
+
+        Parameters
+        ----------
+        json_obj : dict
+            JSON for a complete serialized representation of an instance.
+
+        Returns
+        -------
+        Tuple[DataCategory, bool, Optional[TimeRange], Optional[str], Optional[int]]
+            Tuple of deserialized values of data category, is_input, time_params, fulfilled_by dataset name, and size.
+        """
+        category = DataCategory.get_for_name(json_obj[cls._KEY_CATEGORY])
+        is_input = json_obj[cls._KEY_IS_INPUT]
+        if cls._KEY_TIME_PARAMS in json_obj:
+            time_params = TimeRange.factory_init_from_deserialized_json(json_obj[cls._KEY_TIME_PARAMS])
+        else:
+            time_params = None
+        fulfilled_by = json_obj[cls._KEY_FULFILLED_BY] if cls._KEY_FULFILLED_BY in json_obj else None
+        size = json_obj[cls._KEY_SIZE] if cls._KEY_SIZE in json_obj else None
+        return category, is_input, time_params, fulfilled_by, size
+
+    @classmethod
+    def factory_init_from_deserialized_json(cls, json_obj: dict) -> Optional['DataRequirement']:
+        """
+        Deserialize the given JSON to a ::class:`DataRequirement` instance, or return ``None`` if it is not valid.
+
+        Implementation recursively searches for the appropriate subtype class based on the value of the subclass name.
+        It then calls that class's implementation of this function and returns the value.
+
+        The subclass name is serialized under the ::attribute:`_KEY_REQ_SUBTYPE` serialization key; i.e., accessible via
+        the ``_KEY_REQ_SUBTYPE`` class attribute.
+
+        A safeguard is provided to prevent recursively calling this function again in cases when the found subtype does
+        not provide its own override implementation.  In such cases, ``None`` is returned.
+
+        Parameters
+        ----------
+        json_obj : dict
+            The JSON to be deserialized.
+
+        Returns
+        -------
+        Optional[DataRequirement]
+            A deserialized ::class:`DataRequirement` instance, or return ``None`` if the JSON is not valid.
+        """
+        # Bail if we can't even begin to determine the right subclass to deserialize
+        if cls._KEY_REQ_SUBTYPE not in json_obj:
+            return None
+
+        # Avoid recursive infinite loop by adding an indicator key and bailing if we already see it
+        # This happens when the subtype doesn't provide its own implementation of this function (and so uses this one)
+        recursive_loop_key = 'base_type_invoked_twice'
+        if recursive_loop_key in json_obj:
+            # TODO: consider some kind of default serialization
+            return None
+        else:
+            json_obj[recursive_loop_key] = True
+
+        # Traverse recursively to find all subclasses, searching for the one matching the expected serialized type name
+        expected_subtype = json_obj[cls._KEY_REQ_SUBTYPE]
+        subclasses = []                 # A queue of subclasses to process
+        traversed_subclasses = set()    # A queue of subclasses that have already been examined
+
+        subclasses.extend(cls.__subclasses__())
+        while len(set(subclasses)) > len(traversed_subclasses):
+            for subclass in subclasses:
+                if subclass not in traversed_subclasses:
+                    if subclass.__name__ == expected_subtype:
+                        # Once we have the result back, remove the recursive loop key guard
+                        deserialized = subclass.factory_init_from_deserialized_json(json_obj)
+                        json_obj.pop(recursive_loop_key)
+                        return deserialized
+                    else:
+                        subclasses.extend(subclass.__subclasses__())
+                        traversed_subclasses.add(subclass)
+        # Again, if we arrive here, the risk of recursive subtype calls is over, so remove the recursive loop key guard
+        json_obj.pop(recursive_loop_key)
+        return None
+
+    def __init__(self, domain_params: DOMAIN_PARAM_TYPE, is_input: bool, category: DataCategory,
+                 time_params: Optional[TimeRange] = None, size: Optional[int] = None,
+                 fulfilled_by: Optional[str] = None):
+        self._domain_params = domain_params
+        self._is_input = is_input
+        self._category = category
+        self._time_params = time_params
+        self._size = size
+        self._fulfilled_by = fulfilled_by
+
+    @property
+    def category(self) -> DataCategory:
+        """
+        The ::class:`DataCategory` of data required.
+
+        Returns
+        -------
+        DataCategory
+            The category of data required.
+        """
+        return self._category
+
+    @property
+    def domain_params(self) -> DOMAIN_PARAM_TYPE:
+        """
+        Parameters for defining the domain of the required data.
+
+        Note that time-based params should be handled separately by ::attribute:`time_params`.  Also, data fields
+        details should also be handled implicitly by being encoded within the ::attribute:`category` property value.
+
+        Returns
+        -------
+        DOMAIN_PARAM_TYPE
+            The domain parameters object.
+        """
+        return self._domain_params
+
+    @property
+    def fulfilled_by(self) -> Optional[str]:
+        """
+        The name of the dataset that will fulfill this, if it is known.
+
+        Returns
+        -------
+        Optional[str]
+            The name of the dataset that will fulfill this, if it is known; ``None`` otherwise.
+        """
+        return self._fulfilled_by
+
+    @fulfilled_by.setter
+    def fulfilled_by(self, name: str):
+        self._fulfilled_by = name
+
+    @property
+    def is_input(self) -> bool:
+        """
+        Whether this represents required input data, as opposed to a requirement for storing output data.
+
+        Returns
+        -------
+        bool
+            Whether this represents required input data.
+        """
+        return self._is_input
+
+    @abstractmethod
+    def serialize_domain_params(self) -> Dict[str, Union[str, Number, dict, list]]:
+        """
+        Serialize ::attribute:`domain_params` in a way consistent with ::method:`Serializable.to_dict()`.
+
+        Returns
+        -------
+        Dict[str, Union[str, Number, dict, list]]
+            The serialized form of ::attribute:`domain_params`.
+        """
+        pass
+
+    @property
+    def size(self) -> Optional[int]:
+        """
+        The size of the required data, if it is known.
+
+        This is particularly important (though still not strictly required) for an output data requirement; i.e., a
+        requirement to store output data somewhere.
+
+        Returns
+        -------
+        Optional[int]
+            he size of the required data, if it is known, or ``None`` otherwise.
+        """
+        return self._size
+
+    @property
+    def time_params(self) -> Optional[TimeRange]:
+        """
+        Time range parameters for this required data, if applicable.
+
+        Returns
+        -------
+        Optional[TimeRange]
+            Time range parameters for this required data, if applicable.
+        """
+        return self._time_params
+
+    def to_dict(self) -> Dict[str, Union[str, Number, dict, list]]:
+        serial = {}
+        serial[self._KEY_REQ_SUBTYPE] = self.__class__.__name__
+        serial[self._KEY_DOMAIN_PARAMS] = self.serialize_domain_params()
+        serial[self._KEY_IS_INPUT] = self.is_input
+        serial[self._KEY_CATEGORY] = self.category.name
+        if self.size is not None:
+            serial[self._KEY_SIZE] = self.size
+        if self.time_params is not None:
+            serial[self._KEY_TIME_PARAMS] = self.time_params
+        if self.fulfilled_by is not None:
+            serial[self._KEY_FULFILLED_BY] = self.fulfilled_by
+        return serial
+
+
+class CatchmentDataRequirement(DataRequirement[SubsetDefinition]):
+    """
+    Extension of ::class:`DataRequirement` over some domain of catchments.
+
+    Type uses a ::class:`SubsetDefinition` object for its domain parameters, as this effectively encapsulates a
+    collection of catchments.
+    """
+
+    @classmethod
+    def factory_init_from_deserialized_json(cls, json_obj: dict) -> Optional['CatchmentDataRequirement']:
+        """
+        Deserialize JSON to a ::class:`CatchmentDataRequirement` instance, or return ``None`` if it is not valid.
+
+        Parameters
+        ----------
+        json_obj : dict
+            The JSON to be deserialized.
+
+        Returns
+        -------
+        Optional[CatchmentDataRequirement]
+            A deserialized ::class:`CatchmentDataRequirement` instance, or return ``None`` if the JSON is not valid.
+        """
+        try:
+            category, is_input, time_params, fulfilled_by, size = cls._deserialize_common(json_obj)
+            domain_params = SubsetDefinition.factory_init_from_deserialized_json(json_obj[cls._KEY_DOMAIN_PARAMS])
+            return cls(is_input=is_input, domain_params=domain_params, time_params=time_params, category=category,
+                       fulfilled_by=fulfilled_by, size=size)
+        except:
+            return None
+
+    def serialize_domain_params(self) -> Dict[str, Union[str, Number, dict, list]]:
+        """
+        Serialize ::attribute:`domain_params` in a way consistent with ::method:`Serializable.to_dict()`.
+
+        For this type, since ::attribute:`domain_params` is of a ::class:`Serializable` subtype, the standard
+        serialization mechanisms are used.
+
+        Returns
+        -------
+        Dict[str, Union[str, Number, dict, list]]
+            The serialized form of ::attribute:`domain_params`.
+        """
+        return self.domain_params.to_dict()

--- a/python/lib/modeldata/dmod/test/test_catchment_data_requirement.py
+++ b/python/lib/modeldata/dmod/test/test_catchment_data_requirement.py
@@ -1,0 +1,58 @@
+import unittest
+from ..modeldata.data import CatchmentDataRequirement, DataRequirement, DataCategory
+from ..modeldata.subset import SubsetDefinition
+
+
+class TestCatchmentDataRequirement(unittest.TestCase):
+
+    def setUp(self) -> None:
+        example_subset_defs = []
+        example_subset_defs.append(SubsetDefinition(catchment_ids=['cat-1'], nexus_ids=['nex-1']))
+
+        self.example_reqs = []
+        self.example_reqs.append(CatchmentDataRequirement(domain_params=example_subset_defs[0], is_input=True,
+                                                          category=DataCategory.FORCING))
+
+    def tearDown(self) -> None:
+        pass
+
+    def test_domain_params_0_a(self):
+        """
+        Test domain params returns the right type.
+        """
+        ex = 0
+        requirement = self.example_reqs[ex]
+        domain_params: SubsetDefinition = requirement.domain_params
+        self.assertTrue(isinstance(domain_params, SubsetDefinition))
+
+    def test_to_dict_0_a(self):
+        ex = 0
+        requirement = self.example_reqs[ex]
+        as_dict = requirement.to_dict()
+        self.assertTrue(isinstance(as_dict, dict))
+        self.assertEqual(CatchmentDataRequirement.__name__, as_dict[CatchmentDataRequirement._KEY_REQ_SUBTYPE])
+
+    def test_factory_init_from_deserialized_json_0_a(self):
+        """
+        Test that the general functionality works for example 0.
+        """
+        ex = 0
+        requirement = self.example_reqs[ex]
+        as_dict = requirement.to_dict()
+        duplicate = CatchmentDataRequirement.factory_init_from_deserialized_json(as_dict)
+        self.assertEqual(requirement.category, duplicate.category)
+        self.assertEqual(requirement.domain_params, duplicate.domain_params)
+        self.assertEqual(requirement.is_input, duplicate.is_input)
+
+    def test_factory_init_from_deserialized_json_0_b(self):
+        """
+        Test that the superclass recursive call functionality works for example 0.
+        """
+        ex = 0
+        requirement = self.example_reqs[ex]
+        as_dict = requirement.to_dict()
+        duplicate = DataRequirement.factory_init_from_deserialized_json(as_dict)
+        self.assertEqual(duplicate.__class__, requirement.__class__)
+        self.assertEqual(requirement.category, duplicate.category)
+        self.assertEqual(requirement.domain_params, duplicate.domain_params)
+        self.assertEqual(requirement.is_input, duplicate.is_input)

--- a/python/lib/scheduler/dmod/scheduler/__init__.py
+++ b/python/lib/scheduler/dmod/scheduler/__init__.py
@@ -1,6 +1,6 @@
 from .rsa_key_pair import RsaKeyPair
 from .ssh_key_util import SshKeyUtil, SshKeyUtilImpl
 from .utils import *
-from .scheduler import Launcher
+from .scheduler import SimpleDockerUtil, Launcher
 from .resources import RedisManager, Resource
 name = 'scheduler'

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -768,6 +768,19 @@ class Job(Serializable, ABC):
 
     @property
     @abstractmethod
+    def should_release_resources(self) -> bool:
+        """
+        Whether the job has entered a state where it is appropriate to release resources.
+
+        Returns
+        -------
+        bool
+            Whether the job has entered a state where it is appropriate to release resources.
+        """
+        pass
+
+    @property
+    @abstractmethod
     def status(self) -> JobStatus:
         """
         The ::class:`JobStatus` of this object.
@@ -1225,6 +1238,21 @@ class JobImpl(Job):
         if key_pair != self._rsa_key_pair:
             self._rsa_key_pair = key_pair
             self._reset_last_updated()
+
+    @property
+    def should_release_resources(self) -> bool:
+        """
+        Whether the job has entered a state where it is appropriate to release resources.
+
+        Returns
+        -------
+        bool
+            Whether the job has entered a state where it is appropriate to release resources.
+        """
+        # TODO: update to account for JobCategory
+        # TODO: confirm that allocations should be maintained for stopped model exec jobs while in output phase
+        # TODO: confirm that allocations should be maintained for stopped output jobs while in eval or calibration phase
+        return self.status_step == JobExecStep.FAILED or self.status_phase == JobExecPhase.CLOSED
 
     @property
     def status(self) -> JobStatus:

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -1,9 +1,12 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
+from numbers import Number
+
 from dmod.communication import MaaSRequest, ModelExecRequest, SchedulerRequestMessage
 from dmod.communication.serializeable import Serializable
 from enum import Enum
-from typing import List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+from uri import URI
 from uuid import UUID
 from uuid import uuid4 as uuid_func
 
@@ -13,6 +16,181 @@ if TYPE_CHECKING:
     from .. import RsaKeyPair
 
 import logging
+
+
+class WorkerDataRequirement(Serializable):
+    """
+    A definition of a particular data requirement for a job worker.
+
+    This encapsulates, from the perspective of a task worker (e.g., a Docker container allocated for a Job), the means
+    to access data outside the worker, where the data from that source will be accessible to/within the worker, and a
+    few additional pieces of metadata.  The intent is to provide a way to describe worker external data needs, both for
+    input data a worker must consume, and for non-temporary storage of produced worker output.
+
+    The ::attribute:`requires_transformation` property indicates whether there is data at the optional
+    ::attribute:`raw_source_uri` that needs to be transformed or filtered in some manner.  When this is the case, the
+    expectation is that some external service will perform the necessary transformation/filtering and place the result
+    into ::attribute:`source_uri` for a worker to then use.
+
+    The optional ::attribute:`additional_params` property can also be used to contain more complex, dynamic details on
+    requirements for data, including any pertinent to transformation/filtering.
+    """
+
+    @classmethod
+    def factory_init_from_deserialized_json(cls, json_obj: dict) -> Optional['WorkerDataRequirement']:
+        """
+        Deserialize the given JSON to a ::class:`WorkerDataRequirement` instance, or return ``None`` if it is not valid.
+
+        Parameters
+        ----------
+        json_obj : dict
+            The JSON to be deserialized.
+
+        Returns
+        -------
+        Optional[WorkerDataRequirement]
+            A deserialized ::class:`WorkerDataRequirement` instance, or return ``None`` if the JSON is not valid.
+        """
+        try:
+            return cls(source_uri=URI(json_obj['source_uri']),
+                       worker_path=json_obj['worker_path'],
+                       is_directory=json_obj['is_directory'],
+                       is_input=json_obj['is_input'],
+                       size=json_obj['size'] if 'size' in json_obj else None,
+                       raw_source_uri=URI(json_obj['raw_source_uri']) if 'raw_source_uri' in json_obj else None,
+                       additional_params=json_obj['additional_params'] if 'additional_params' in json_obj else None)
+        except:
+            return None
+
+    def __init__(self, source_uri: URI, worker_path: str, is_directory: bool, is_input: bool, size: Optional[int],
+                 raw_source_uri: Optional[URI] = None, additional_params: Optional[dict] = None):
+        self._source_uri = source_uri
+        self._worker_path = worker_path
+        self._is_directory = is_directory
+        self._is_input = is_input
+        self._size = size
+        self._raw_source_uri = raw_source_uri
+        self._additional_params = additional_params
+
+    @property
+    def additional_params(self) -> Optional[Dict[str, Union[str, Number, bool, dict, list]]]:
+        """
+        Additional dynamic parameters describing the requirements for this data, if any.
+
+        It is expected that, when present, this dictionary follow the same typing rules as the serialized dictionaries
+        for all ::class:`Serializable` objects.
+
+        Returns
+        -------
+        Optional[Dict[str, Union[str, Number, dict, list]]]
+            Additional dynamic parameters describing the requirements for this data, if any.
+        """
+        return self._additional_params
+
+    @property
+    def is_directory(self) -> bool:
+        """
+        Whether this represents a directory or required data, as opposed to an individual file.
+
+        Returns
+        -------
+        bool
+            Whether this represents a directory or required data, as opposed to an individual file.
+        """
+        return self._is_directory
+
+    @property
+    def is_input(self) -> bool:
+        """
+        Whether this represents required input data, as opposed to required location to store output data.
+
+        Returns
+        -------
+        bool
+            Whether this represents required input data.
+        """
+        return self._is_input
+
+    @property
+    def raw_source_uri(self) -> Optional[URI]:
+        """
+        A "raw" source data URI, for when data transformation is needed.
+
+        Returns
+        -------
+        Optional[URI]
+            A "raw" source data URI, for when data transformation is needed.
+        """
+        return self._raw_source_uri
+
+    @property
+    def requires_transformation(self) -> bool:
+        """
+        Whether some kind of transformation is/was needed to make data available at the referenced source.
+
+        Indicates whether there is data at the optional ::attribute:`raw_source_uri` that must be transformed or
+        filtered in some manner in order to yield the required data this instance references.  When this is the case,
+        the expectation is that some external service will perform the necessary transformation/filtering and place the
+        result into ::attribute:`source_uri` for a worker to then use.
+
+        Returns
+        -------
+        bool
+            Whether some kind of transformation is/was needed to make data available at the referenced source.
+        """
+        return self.raw_source_uri is not None
+
+    @property
+    def size(self) -> Optional[int]:
+        """
+        The size of the required data, if it is known.
+
+        Returns
+        -------
+        Optional[int]
+            he size of the required data, if it is known, or ``None`` otherwise.
+        """
+        return self._size
+
+    @property
+    def source_uri(self) -> URI:
+        """
+        A ::class:`URI` object defining the source for this required data.
+
+        Returns
+        -------
+        URI
+            The source identifier for this required data.
+        """
+        return self._source_uri
+
+    @property
+    def worker_path(self) -> str:
+        """
+        The path on a job worker's filesystem at which to expect to find this required data.
+
+        Returns
+        -------
+        str
+            The path on a job worker's filesystem at which to expect to find this required data.
+        """
+        return self._worker_path
+
+    def to_dict(self) -> Dict[str, Union[str, Number, bool, dict, list]]:
+        serial = dict()
+        serial['source_uri'] = str(self.source_uri)
+        serial['worker_path'] = self.worker_path
+        # TODO: might need to fix support for bool type in Dict hinting in communication package
+        serial['is_directory'] = self.is_directory
+        serial['is_input'] = self.is_input
+        if self.size is not None:
+            serial['size'] = self.size
+        if self.requires_transformation:
+            serial['raw_source_uri'] = str(self.raw_source_uri)
+        if self.additional_params is not None:
+            serial['additional_params'] = self.additional_params
+
+        return serial
 
 
 class JobAllocationParadigm(Enum):

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -296,6 +296,27 @@ class JobExecStep(Enum):
     FAILED = (-1, True, True)
     """ The step indicating failure happened that stopped a job after it entered the ``RUNNING`` step. """
 
+    @classmethod
+    def get_for_name(cls, name: str) -> Optional['JobExecStep']:
+        """
+        Parse the given name to its associated enum value, ignoring case and leading/trailing whitespace.
+
+        Parameters
+        ----------
+        name : str
+            The name of the desired enum value.
+
+        Returns
+        -------
+        JobExecStep
+            The associated enum value, or ``None`` if the name could not be parsed to one.
+        """
+        formatted_name = name.strip().upper()
+        for value in cls:
+            if formatted_name == value.name.upper():
+                return value
+        return None
+
     def __hash__(self):
         return self.uid
 
@@ -349,6 +370,27 @@ class JobExecPhase(Enum):
     OUTPUT_EXEC = (3, True, JobExecStep.AWAITING_ALLOCATION)
     CLOSED = (4, False, JobExecStep.COMPLETED)
     UNKNOWN = (-1, False, JobExecStep.DEFAULT)
+
+    @classmethod
+    def get_for_name(cls, name: str) -> Optional['JobExecPhase']:
+        """
+        Parse the given name to its associated enum value, ignoring case and leading/trailing whitespace.
+
+        Parameters
+        ----------
+        name : str
+            The name of the desired enum value.
+
+        Returns
+        -------
+        JobExecPhase
+            The associated enum value, or ``None`` if the name could not be parsed to one.
+        """
+        formatted_name = name.strip().upper()
+        for value in cls:
+            if formatted_name == value.name.upper():
+                return value
+        return None
 
     def __hash__(self):
         return self.uid

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -108,7 +108,7 @@ class JobExecStep(Enum):
     """ The step after job is allocated, when any necessary acquiring/processing/preprocessing of data is performed. """
     DATA_FAILURE = (-3, True, True)
     """ The step after unexpected error in obtaining or deriving required data that earlier was deemed provideable. """
-    ALLOCATED = (2, False, False)
+    AWAITING_SCHEDULING = (2, False, False)
     """ The step after a job has resources allocated and all required data is ready and available. """
     SCHEDULED = (3, False, False)
     """ The step after a job has been scheduled. """

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -1265,7 +1265,7 @@ class JobImpl(Job):
             "allocation_priority" : 0,
             "job_id" : "12345678-1234-5678-1234-567812345678",
             "rsa_key_pair" : {<serialized_representation_of_RsaKeyPair_obj>},
-            "status" : CREATED,
+            "status" : INIT:DEFAULT,
             "last_updated" : "2020-07-10 12:05:45",
             "allocations" : [...]
         }
@@ -1406,7 +1406,7 @@ class RequestedJob(JobImpl):
             "allocation_priority" : 0,
             "job_id" : "12345678-1234-5678-1234-567812345678",
             "rsa_key_pair" : {<serialized_representation_of_RsaKeyPair_obj>},
-            "status" : CREATED,
+            "status" : INIT:DEFAULT,
             "last_updated" : "2020-07-10 12:05:45",
             "allocations" : [...],
             "originating_request" : {<serialized_representation_of_originating_message>}

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -273,8 +273,8 @@ class JobExecStep(Enum):
     # TODO: come back and add another property for workflow ordering, separate from uid
     DEFAULT = (0, False, False)
     """ The default starting step. """
-    CHECKING_DATA = (7, False, False)
-    """ The step during which a check is performed to make sure required data is directly or implicitly available. """
+    AWAITING_DATA_CHECK = (7, False, False)
+    """ The step indicating a check is needed for availability of required data . """
     DATA_UNPROVIDEABLE = (-2, True, True)
     """ The error step that occurs if/when it is determined that required data is missing and cannot be obtained. """
     AWAITING_ALLOCATION = (1, False, False)
@@ -361,7 +361,7 @@ class JobExecPhase(Enum):
     A component of a JobStatus, representing the high level transition stage at which a status exists.
     """
     INIT = (1, True, JobExecStep.DEFAULT)
-    MODEL_EXEC = (2, True, JobExecStep.CHECKING_DATA)
+    MODEL_EXEC = (2, True, JobExecStep.AWAITING_DATA_CHECK)
     # TODO: this one may no longer be appropriate, depending on how we do output (may need to be an exec step instead)
     # TODO: alternatively for certain job categories, perhaps this is when, e.g., evaluation is done
         # TODO: in that alternative, perhaps jobs of certain categories return to the exec phase (e.g, calibration)

--- a/python/lib/scheduler/dmod/scheduler/job/job_manager.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job_manager.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from asyncio import sleep
 from typing import Dict, Iterable, List, Optional, Tuple, Union
 from uuid import UUID, uuid4 as random_uuid
-from .job import Job, JobAllocationParadigm, JobExecStep, JobStatus, RequestedJob
+from .job import Job, JobAllocationParadigm, JobExecPhase, JobExecStep, JobStatus, RequestedJob
 from ..resources.resource_allocation import ResourceAllocation
 from ..resources.resource_manager import ResourceManager
 from ..rsa_key_pair import RsaKeyPair
@@ -413,11 +413,10 @@ class RedisBackedJobManager(JobManager, RedisBacked):
 
     def _organize_active_jobs(self, active_jobs: List[RequestedJob]) -> List[List[RequestedJob]]:
         """
-        Organize the given list of active jobs into collections ready for various next-steps in their processing,
-        potentially with some housekeeping performed (i.e. side effects).
+        Organize active jobs into collections ready to prepare for certain next-steps in processing.
 
-        In some cases, job status may be changed (e.g., ``CREATED`` to ``MODEL_EXEC_AWAITING_ALLOCATION``).  In those
-        cases and a few other situations, the updated job object will have its state re-saved using ::method:`save_job`.
+        Organize the given list of active jobs into collections ready for certain specific next-steps in their
+        processing, potentially with some housekeeping performed (i.e. side effects).
 
         Parameters
         ----------
@@ -437,11 +436,13 @@ class RedisBackedJobManager(JobManager, RedisBacked):
         jobs_completed_phase = []
 
         for job in active_jobs:
-            # Transition CREATED to awaiting allocation as a first step for them
-            if job.status == JobStatus.CREATED:
-                job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+            # Transition newly created to their first appropriate phase and step
+            if job.status_phase == JobExecPhase.INIT:
+                # TODO: revisit this for JobCategory (remember right now this is the only way AWAITING_DATA_CHECK is entered, via default step)
+                job.status = JobStatus(phase=JobExecPhase.MODEL_EXEC)
                 self.save_job(job)
             # TODO: figure out for STOPPED and FAILED if there are implications that require maintaining the same allocation
+            # TODO: figure out for FAILED if restart should be automatic or should require manual request to restart
             # Note that this code should be safe as is as long as the job itself still has the previous allocation saved
             # in situations when it needs to use the same allocation as before
             if job.status_step == JobExecStep.STOPPED:
@@ -461,10 +462,10 @@ class RedisBackedJobManager(JobManager, RedisBacked):
                 else:
                     # TODO: confirm the allocation is still valid (saving it without checking will make it so, which
                     #  could lead to inconsistencies)
-                    job.status_step = JobExecStep.ALLOCATED
+                    job.status_step = JobExecStep.AWAITING_DATA
                     self.save_job(job)
 
-            if job.status.should_release_allocations:
+            if job.should_release_resources:
                 jobs_to_release_resources.append(job)
 
             if job.status_step == JobExecStep.COMPLETED:
@@ -685,8 +686,10 @@ class RedisBackedJobManager(JobManager, RedisBacked):
                 allocated_successfully.extend(self._request_allocations_for_queue(med_priority_queue))
                 allocated_successfully.extend(self._request_allocations_for_queue(low_priority_queue))
 
-            # For each Job that received an allocation, save updated state and pass to scheduler
-            for job in allocated_successfully:
+            # TODO: have data management service handle the AWAITING_DATA step so it can transition to the AWAITING_SCHEDULING step
+
+            # For each Job that is at the AWAITING_SCHEDULING, save updated state and pass to scheduler
+            for job in [j for j in active_jobs if j.status_step == JobExecStep.AWAITING_SCHEDULING]:
                 if self.request_scheduling(job):
                     job.status_step = JobExecStep.SCHEDULED
                 else:
@@ -694,7 +697,7 @@ class RedisBackedJobManager(JobManager, RedisBacked):
                     # TODO: probably log something about this, or raise exception
                 self.save_job(job)
 
-            await sleep(60)
+            await sleep(5)
 
     def release_allocations(self, job: Job):
         """
@@ -746,7 +749,7 @@ class RedisBackedJobManager(JobManager, RedisBacked):
             alloc = [None]
         if isinstance(alloc, list) and len(alloc) > 0 and isinstance(alloc[0], ResourceAllocation):
             job.allocations = alloc
-            job.status_step = JobExecStep.ALLOCATED
+            job.status_step = JobExecStep.AWAITING_DATA
             return True
         else:
             return False

--- a/python/lib/scheduler/dmod/scheduler/job/job_manager.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job_manager.py
@@ -636,7 +636,7 @@ class RedisBackedJobManager(JobManager, RedisBacked):
             TODO rename this function, by the time we get here, we are already scheduled, just need to run
         """
         # TODO: make sure there aren't other cases
-        if job.status_step == JobExecStep.ALLOCATED:
+        if job.status_step == JobExecStep.AWAITING_SCHEDULING:
             try: #If we don't catch excpetions from the launcher, they get handled "somewhere" that causes the
                  #connection to close, but no useful information is provided, so handle them here.
                 return self._launcher.start_job(job)

--- a/python/lib/scheduler/dmod/test/it_RedisBackedJobManager.py
+++ b/python/lib/scheduler/dmod/test/it_RedisBackedJobManager.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from ..scheduler.job.job import Job, JobStatus, RequestedJob, SchedulerRequestMessage
+from ..scheduler.job.job import Job, JobStatus, JobExecPhase, JobExecStep, RequestedJob, SchedulerRequestMessage
 from ..scheduler.job.job_manager import RedisBackedJobManager
 from ..scheduler.rsa_key_pair import RsaKeyPair
 from . import MockResourceManager, mock_resources
@@ -386,7 +386,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
     def test_request_allocations_1_a(self):
         example_index = 0
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
-        self.assertNotEqual(created_job.status, JobStatus.MODEL_EXEC_AWAITING_ALLOCATION)
+        self.assertNotEqual(created_job.status, JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION))
         self.assertFalse(self._job_manager.request_allocations(created_job))
 
     # Test request_allocations for a job with a single-node allocation paradigm succeeds
@@ -394,7 +394,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 0
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self.assertTrue(self._job_manager.request_allocations(created_job))
 
     # Test request_allocations for a job with a single-node allocation paradigm gets back a tuple
@@ -402,7 +402,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 0
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self._job_manager.request_allocations(created_job)
         # Should be one allocation for single-node
         self.assertTrue(isinstance(created_job.allocations, tuple))
@@ -412,7 +412,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 0
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self._job_manager.request_allocations(created_job)
         allocations = created_job.allocations
         # Should be one allocation for single-node
@@ -423,7 +423,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 0
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self._job_manager.request_allocations(created_job)
         allocations = created_job.allocations
         # Should be one allocation for single-node, with right number of cpus
@@ -434,7 +434,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 0
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self._job_manager.request_allocations(created_job)
         allocations = created_job.allocations
         # Should be one allocation for single-node, with right number of cpus
@@ -445,7 +445,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 2
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self.assertTrue(self._job_manager.request_allocations(created_job))
 
     # Test request_allocations for a job with a fill-nodes allocation paradigm gets back a tuple
@@ -453,7 +453,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 2
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self._job_manager.request_allocations(created_job)
         allocations = created_job.allocations
         # Should be one allocation for fill-nodes
@@ -464,7 +464,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 2
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self._job_manager.request_allocations(created_job)
         allocations = created_job.allocations
         # Should be one allocation for fill-nodes
@@ -475,7 +475,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 2
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self._job_manager.request_allocations(created_job)
         allocations = created_job.allocations
         # Should be one allocation for fill-nodes, with right number of cpus
@@ -486,7 +486,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 2
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self._job_manager.request_allocations(created_job)
         allocations = created_job.allocations
         # Should be one allocation for fill-nodes, with right number of cpus
@@ -497,7 +497,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 3
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self.assertTrue(self._job_manager.request_allocations(created_job))
 
     # Test request_allocations for a job with a round-robin allocation paradigm gets back a tuple
@@ -505,7 +505,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 3
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self._job_manager.request_allocations(created_job)
         allocations = created_job.allocations
         self.assertTrue(isinstance(allocations, tuple))
@@ -515,7 +515,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 3
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self._job_manager.request_allocations(created_job)
         allocations = created_job.allocations
         self.assertEqual(len(allocations), 3)
@@ -525,7 +525,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 3
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self._job_manager.request_allocations(created_job)
         allocations = created_job.allocations
         cpu_total = 0
@@ -538,7 +538,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 3
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self._job_manager.request_allocations(created_job)
         allocations = created_job.allocations
         # FIXME: for now, resource allocation does not properly handle memory across multiple nodes, instead getting the
@@ -553,7 +553,7 @@ class IntegrationTestRedisBackedJobManager(unittest.TestCase):
         example_index = 0
         expected_job, created_job = self._exec_job_manager_create_from_expected(example_index)
         # We will need to adjust the status
-        created_job.status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
+        created_job.status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
         self._job_manager.request_allocations(created_job)
         self._job_manager.save_job(created_job)
         retrieved_job_1 = self._job_manager.retrieve_job(created_job.job_id)

--- a/python/lib/scheduler/setup.py
+++ b/python/lib/scheduler/setup.py
@@ -17,6 +17,6 @@ setup(
     author_email='',
     url='',
     license='',
-    install_requires=['docker', 'Faker', 'dmod-communication>=0.4.2', 'dmod-redis>=0.1.0'],
+    install_requires=['docker', 'Faker', 'dmod-communication>=0.4.2', 'dmod-redis>=0.1.0', 'uri'],
     packages=find_namespace_packages(exclude=('test', 'src'))
 )

--- a/python/lib/scheduler/setup.py
+++ b/python/lib/scheduler/setup.py
@@ -17,6 +17,6 @@ setup(
     author_email='',
     url='',
     license='',
-    install_requires=['docker', 'Faker', 'dmod-communication>=0.4.2', 'dmod-redis>=0.1.0', 'uri'],
+    install_requires=['docker', 'Faker', 'dmod-communication>=0.4.2', 'dmod-modeldata>=0.5.0', 'dmod-redis>=0.1.0'],
     packages=find_namespace_packages(exclude=('test', 'src'))
 )

--- a/python/services/monitorservice/dmod/test/test_monitor_service.py
+++ b/python/services/monitorservice/dmod/test/test_monitor_service.py
@@ -4,7 +4,7 @@ from typing import List, Optional, Tuple, Dict
 
 from ..monitorservice.service import Monitor, MonitorService, Job, JobStatus, MetadataMessage, MetadataPurpose,\
     MonitoredChange, MetadataResponse
-from dmod.scheduler.job import JobAllocationParadigm, JobImpl, JobExecStep
+from dmod.scheduler.job import JobAllocationParadigm, JobExecPhase, JobImpl, JobExecStep
 
 
 class MockMonitor(Monitor):
@@ -104,9 +104,9 @@ class TestMonitorService(unittest.TestCase):
         self._connect_metadata_examples.append('{"purpose": "PROMPT", "additional_metadata": false}')
         self._connect_metadata_examples.append('{"purpose": "CONNECT", "additional_metadata": true}')
 
-        self._jobs[0].status = JobStatus.MODEL_EXEC_AWAITING_ALLOCATION
-        self._jobs[1].status = JobStatus.MODEL_EXEC_ALLOCATED
-        self._jobs[2].status = JobStatus.MODEL_EXEC_SCHEDULED
+        self._jobs[0].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
+        self._jobs[1].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.ALLOCATED)
+        self._jobs[2].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.SCHEDULED)
 
         self._services.append(MockMonitorService(MockMonitor(monitored_jobs=self._jobs)))
 
@@ -114,9 +114,9 @@ class TestMonitorService(unittest.TestCase):
         for j in self._jobs:
             self._original_statuses.append(j.status)
 
-        self._jobs[0].status = JobStatus.MODEL_EXEC_ALLOCATED
-        self._jobs[1].status = JobStatus.MODEL_EXEC_SCHEDULED
-        self._jobs[2].status = JobStatus.MODEL_EXEC_RUNNING
+        self._jobs[0].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.ALLOCATED)
+        self._jobs[1].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.SCHEDULED)
+        self._jobs[2].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.RUNNING)
 
         self._job_ids = list()
         self._jobs_by_id = dict()
@@ -132,6 +132,13 @@ class TestMonitorService(unittest.TestCase):
 
     def tearDown(self) -> None:
         pass
+
+    def _generate_all_status_values(self) -> List[JobStatus]:
+        all_statuses = []
+        for phase in JobExecPhase:
+            for step in JobExecStep:
+                all_statuses.append(JobStatus(phase, step))
+        return all_statuses
 
     # Test object type for simple example change example for job
     def test__generate_update_msg_1_a(self):
@@ -911,7 +918,7 @@ class TestMonitorService(unittest.TestCase):
         job = self._jobs[1]
         original_status = job.status
         get_next_one = False
-        for status in JobStatus:
+        for status in self._generate_all_status_values():
             if get_next_one:
                 job.status = status
                 break
@@ -941,7 +948,8 @@ class TestMonitorService(unittest.TestCase):
         job = self._jobs[1]
         original_status = job.status
         get_next_one = False
-        for status in JobStatus:
+
+        for status in self._generate_all_status_values():
             if get_next_one:
                 job.status = status
                 break
@@ -967,7 +975,7 @@ class TestMonitorService(unittest.TestCase):
         job = self._jobs[1]
         original_status = job.status
         get_next_one = False
-        for status in JobStatus:
+        for status in self._generate_all_status_values():
             if get_next_one:
                 job.status = status
                 break

--- a/python/services/monitorservice/dmod/test/test_monitor_service.py
+++ b/python/services/monitorservice/dmod/test/test_monitor_service.py
@@ -105,7 +105,7 @@ class TestMonitorService(unittest.TestCase):
         self._connect_metadata_examples.append('{"purpose": "CONNECT", "additional_metadata": true}')
 
         self._jobs[0].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
-        self._jobs[1].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.ALLOCATED)
+        self._jobs[1].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_SCHEDULING)
         self._jobs[2].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.SCHEDULED)
 
         self._services.append(MockMonitorService(MockMonitor(monitored_jobs=self._jobs)))
@@ -114,7 +114,7 @@ class TestMonitorService(unittest.TestCase):
         for j in self._jobs:
             self._original_statuses.append(j.status)
 
-        self._jobs[0].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.ALLOCATED)
+        self._jobs[0].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_SCHEDULING)
         self._jobs[1].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.SCHEDULED)
         self._jobs[2].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.RUNNING)
 

--- a/python/services/monitorservice/setup.py
+++ b/python/services/monitorservice/setup.py
@@ -14,6 +14,6 @@ setup(
     author_email='',
     url='',
     license='',
-    install_requires=['dmod-communication>=0.4.2', 'dmod-monitor>=0.5.0'],
+    install_requires=['dmod-communication>=0.4.2', 'dmod-monitor>=0.3.0'],
     packages=find_namespace_packages(exclude=('tests', 'schemas', 'ssl', 'src'))
 )

--- a/python/services/schedulerservice/setup.py
+++ b/python/services/schedulerservice/setup.py
@@ -15,6 +15,6 @@ setup(
     url='',
     license='',
     install_requires=['docker', 'redis', 'cryptography', 'Faker', 'pyyaml', 'dmod-communication>=0.4.2',
-                      'dmod-scheduler>=0.3.0'],
+                      'dmod-scheduler>=0.4.0'],
     packages=find_namespace_packages(exclude=('tests', 'test', 'deprecated', 'conf', 'schemas', 'ssl', 'src'))
 )


### PR DESCRIPTION
Adjustments to jobs, job status and execution state classes, and job services, in preparation to include the necessary pieces for getting forcing, observation, hydrofabric, etc. data in and out of where it needs to be.

The biggest pieces are:

- a new _DataRequirement_ type (plus supporting metadata types) for representing data that something (i.e., a _Job_) needs
- new _JobExecStep_ values to represent points in the job workflow for:
  - the state when a check is performed on whether it is possible to provide a job with data it needs
  - the state when any transformation, obtaining, or filtering of available data is done to get required data
- a redesign of _JobStatus_ to be its own composite type, rather than an enum
- incorporating these things into _Job_ and job manager classes