### PR TITLE
Updated out of date references/comments in the GUI files

### DIFF
--- a/docker/nwm_gui/app_server/Dockerfile
+++ b/docker/nwm_gui/app_server/Dockerfile
@@ -18,10 +18,10 @@ RUN pip install --upgrade --find-links=/DIST ${comms_package_name} \
     # After eventually installing all dist files like this, clean up ... \
     && rm -r /DIST
 
-# Move to a new directory at "/usr/wres-gui"
+# Move to a new directory at "/usr/maas_portal"
 WORKDIR /usr/maas_portal
 # Copy the requirements.txt file in the current directory for the application to the
-# working directory of the docker image (/usr/wres-gui)
+# working directory of the docker image (/usr/maas_portal)
 COPY ./python/gui/requirements.txt ./
 # Install all the python packages described in the requirements file
 RUN pip install -r requirements.txt

--- a/docker/nwm_gui/web_server/nginx/default.conf
+++ b/docker/nwm_gui/web_server/nginx/default.conf
@@ -1,4 +1,4 @@
-upstream wresgui {
+upstream dmod_gui {
     server app_server:8000;
 }
 
@@ -13,7 +13,7 @@ server {
 
     # Redirect the root address to the GUI
     location / {
-        proxy_pass http://wresgui;
+        proxy_pass http://dmod_gui;
         proxy_set_header X-Forwared-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $host;
         proxy_redirect off;


### PR DESCRIPTION
The original proof of concept for the GUI came from a quick and dirty stab based on some resources from the WRES GUI. As a result, there are a few references to the WRES that are wildly low hanging fruit. I figured it would be easy enough to just go ahead and fix them.

There are also some references to `maas_experiment`. If I remember correctly, that `maas_experiment` really was just a reference to the original PoC being an experiment. That should _probably_ be fixed, but there is a higher chance of bugs considering that it would result in the renaming of directories and resources, not just a few comments or aliases.