### PR TITLE
Resolve docker type hint import issue

### DIFF
--- a/python/lib/scheduler/dmod/scheduler/scheduler.py
+++ b/python/lib/scheduler/dmod/scheduler/scheduler.py
@@ -7,6 +7,7 @@ from dmod.core.exception import DmodRuntimeError
 from dmod.core.meta_data import DataCategory, DataFormat
 from os import getenv
 import docker
+from docker.models.services import Service as DockerService
 from docker.types import Mount, SecretReference
 import yaml
 from typing import Dict, List, Optional, TYPE_CHECKING, Tuple
@@ -160,7 +161,7 @@ class Launcher(SimpleDockerUtil):
         self.networks = ["mpi-net"]
 
     def create_service(self, serviceParams: DockerServiceParameters, idx: int, docker_cmd_args: List[str]) \
-        -> docker.from_env().services.create:
+        -> DockerService:
         """
         Create new service with Healthcheck, host, and other info
 


### PR DESCRIPTION
Resolves issue if someone were to import `dmod.scheduler.scheduler` in an environment that does not have `docker` (not `docker`'s sdk) installed. 

fixes #203

## Changes

- Fixed type hint in `dmod.scheduler.scheduler`.


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [x] Windows
- [x] Linux
- [x] Browser

### Accessibility

- [x] Keyboard friendly
- [x] Screen reader friendly

### Other

- [x] No linting errors or warnings
