### PR TITLE
Builds PET (evapotranspiration) and SLoTH modules in ngen container

### DIFF
--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -70,6 +70,8 @@ ARG NGEN_UDUNITS_QUIET="ON"
 ARG BUILD_NOAH_OWP="true"
 ARG BUILD_CFE="true"
 ARG BUILD_TOPMODEL="true"
+ARG BUILD_PET="true"
+ARG BUILD_SLOTH="true"
 
 ################################################################################################################
 ################################################################################################################
@@ -367,7 +369,7 @@ RUN cd ${WORKDIR} \
     #&& echo "cd \$1/cmake_build && make install" >> build_sub \
     && chmod u+x build_sub \
     && git submodule update --init test/googletest \
-    && git submodule update --init
+    && git submodule update --init --recursive
 
 ################################################################################################################
 ################################################################################################################
@@ -400,6 +402,8 @@ ARG NGEN_UDUNITS_QUIET
 ARG BUILD_NOAH_OWP
 ARG BUILD_CFE
 ARG BUILD_TOPMODEL
+ARG BUILD_PET
+ARG BUILD_SLOTH
 
 COPY --chown=${USER} --from=rocky_init_repo ${WORKDIR}/ngen ${WORKDIR}/ngen
 ENV BOOST_ROOT=${WORKDIR}/boost
@@ -412,8 +416,10 @@ RUN cd ${WORKDIR}/ngen \
         fi \
     &&  if [ "${NGEN_ACTIVATE_C}" == "ON" ]; then \
                 if [ "${BUILD_CFE}" == "true" ] ; then ./build_sub extern/cfe; fi; \
+                if [ "${BUILD_PET}" == "true" ] ; then ./build_sub extern/evapotranspiration/evapotranspiration; fi; \
                 if [ "${BUILD_TOPMODEL}" == "true" ] ; then ./build_sub extern/topmodel; fi; \
         fi \
+    && if [ "${BUILD_SLOTH}" == "true" ] ; then ./build_sub extern/sloth; fi \
     && cmake -B cmake_build -S . \
             -DMPI_ACTIVE:BOOL=${NGEN_MPI_ACTIVE} \
             -DNETCDF_ACTIVE:BOOL=${NGEN_NETCDF_ACTIVE} \
@@ -479,7 +485,7 @@ ENV HYDRA_PROXY_RETRY_COUNT=5
 # Change permissions for entrypoint and make sure dataset volume mount parent directories exists
 RUN chmod +x ${WORKDIR}/entrypoint.sh \
     && for d in ${DATASET_DIRECTORIES}; do mkdir -p /dmod/datasets/${d}; done \
-    && for d in noah-owp-modular topmodel cfe; do if [ -d ${WORKDIR}/ngen/extern/${d}/cmake_build ]; then cp -a ${WORKDIR}/ngen/extern/${d}/cmake_build/*.so* /dmod/shared_libs/.; fi; done
+    && for d in noah-owp-modular topmodel cfe sloth 'evapotranspiration/evapotranspiration'; do if [ -d ${WORKDIR}/ngen/extern/${d}/cmake_build ]; then cp -a ${WORKDIR}/ngen/extern/${d}/cmake_build/*.so* /dmod/shared_libs/.; fi; done
 
 WORKDIR ${WORKDIR}
 ENV PATH=${WORKDIR}:$PATH


### PR DESCRIPTION
Builds PET (evapotranspiration) and SLoTH modules in ngen container

## Additions

- Build options and commands to build extern/sloth and extern/evapotranspiration submodules in the ngen container

## Removals

-

## Changes

- Adds `--recursive` to the submodule update command in the build, because SLoTH has googletest and bmi_cxx submodules

## Testing

1. Built this container and ran with a PET-including realization. The .so files show up in /dmod/shared_libs ... everything seems in order.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [X] Windows
- [X] Linux
- [X] Browser

### Accessibility

- [X] Keyboard friendly
- [X] Screen reader friendly

### Other

- [X] No linting errors or warnings
