### PR TITLE
Calibration Prerequisites 

### DIFF
--- a/docker/object_store/docker-compose.yml
+++ b/docker/object_store/docker-compose.yml
@@ -1,7 +1,8 @@
 version: '3.8'
 services:
   minio1:
-    image: minio/minio:latest
+    # TODO: temporary work around of backend storage mount (long term, this will need a different fix)
+    image: minio/minio:RELEASE.2022-10-08T20-11-00Z
     hostname: minio1
     volumes:
       - ${DMOD_OBJECT_STORE_HOST_DIR_1:?No host data directory 1 for object store storage provided}:/export1
@@ -42,7 +43,8 @@ services:
       - source: exec_user_name
         target: exec_user_name
   minio2:
-    image: minio/minio:latest
+    # TODO: temporary work around of backend storage mount (long term, this will need a different fix)
+    image: minio/minio:RELEASE.2022-10-08T20-11-00Z
     hostname: minio2
     volumes:
       - ${DMOD_OBJECT_STORE_HOST_DIR_1:?No host data directory 1 for object store storage provided}:/export1

--- a/docker/object_store/docker-single-node.yml
+++ b/docker/object_store/docker-single-node.yml
@@ -1,7 +1,8 @@
 version: '3.8'
 services:
   minio1:
-    image: minio/minio:latest
+    # TODO: temporary work around of backend storage mount (long term, this will need a different fix)
+    image: minio/minio:RELEASE.2022-10-08T20-11-00Z
     hostname: minio1
     volumes:
       - ${DMOD_OBJECT_STORE_SINGLE_NODE_HOST_DIR:?No host data directory for single-node object store storage provided}:/export

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -22,6 +22,8 @@ class StandardDatasetIndex(Enum):
     """ Index for some type of dataset-scope checksum. """
     ELEMENT_ID = (6, str)
     """ A general-purpose index for the applicable data element unique identifier. """
+    REALIZATION_CONFIG_DATA_ID = (7, str)
+    """ A specialized index for the unique data id of an associated realization config dataset. """
 
     @classmethod
     def get_for_name(cls, name_str: str) -> 'StandardDatasetIndex':
@@ -107,6 +109,20 @@ class DataFormat(Enum):
     """ Format for NWM 2.0/2.1/2.2 output. """
     NWM_CONFIG = (9, {StandardDatasetIndex.ELEMENT_ID: None, StandardDatasetIndex.TIME: None, StandardDatasetIndex.DATA_ID: None}, None)
     """ Format for initial config for NWM 2.0/2.1/2.2. """
+    NGEN_CAL_OUTPUT = (10,
+                       {StandardDatasetIndex.CATCHMENT_ID: None, StandardDatasetIndex.TIME: None,
+                        StandardDatasetIndex.DATA_ID: None},
+                       None,
+                       False)
+    """ Representation of the format for ngen-cal calibration tool output. """
+    # TODO: come back later and fill in details of fields
+    NGEN_CAL_CONFIG = (11,
+                       {StandardDatasetIndex.DATA_ID: None, StandardDatasetIndex.TIME: None,
+                        StandardDatasetIndex.REALIZATION_CONFIG_DATA_ID: None,
+                        StandardDatasetIndex.HYDROFABRIC_ID: None},
+                       None,
+                       False)
+    """ Format representing ngen-cal configurations. """
     # TODO: consider whether a datetime format string is necessary for each type value
     # TODO: consider whether something to indicate the time step size is necessary
     # TODO: need format specifically for Nextgen model output (i.e., for evaluations)


### PR DESCRIPTION
A few prerequisites for the calibration workflow.

## Additions

- New _StandardDatasetIndex_ value of _REALIZATION_CONFIG_DATA_ID_, needed for creating new _DataFormat_ values mentioned below
- New _DataFormat_ values for ngen-cal configuration and output datasets

## Changes

- Workaround for issue in with newer versions of MinIO that do not allow backing storage to be on file system of MinIO node (pins to older version of MinIO image where the required functionality is still available)
