### PR TITLE
Adding Grouped Single-Node Allocation Paradigm

### DIFF
--- a/python/lib/core/dmod/core/execution.py
+++ b/python/lib/core/dmod/core/execution.py
@@ -15,11 +15,13 @@ class AllocationParadigm(Enum):
                       allocations be single cpu/process
         SINGLE_NODE - require all allocation of assets to be from a single resource/host; also, require allocations to
                       be single cpu/process
+        GROUPED_SINGLE_NODE     -   obtain one grouped allocation of required assets, all from a single resource/host
     """
 
     FILL_NODES = 0
     ROUND_ROBIN = 1
     SINGLE_NODE = 2
+    GROUPED_SINGLE_NODE = 3
 
     @classmethod
     def get_default_selection(cls) -> 'AllocationParadigm':

--- a/python/lib/scheduler/dmod/scheduler/job/job_manager.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job_manager.py
@@ -632,6 +632,8 @@ class RedisBackedJobManager(JobManager, RedisBackedJobUtil):
             alloc = self._resource_manager.allocate_fill_nodes(job.cpu_count, job.memory_size)
         elif job.allocation_paradigm == AllocationParadigm.ROUND_ROBIN:
             alloc = self._resource_manager.allocate_round_robin(job.cpu_count, job.memory_size)
+        elif job.allocation_paradigm == AllocationParadigm.GROUPED_SINGLE_NODE:
+            alloc = self._resource_manager.allocate_grouped_single_node(job.cpu_count, job.memory_size)
         else:
             alloc = [None]
         if isinstance(alloc, list) and len(alloc) > 0 and isinstance(alloc[0], ResourceAllocation):

--- a/python/lib/scheduler/dmod/scheduler/resources/resource_manager.py
+++ b/python/lib/scheduler/dmod/scheduler/resources/resource_manager.py
@@ -231,6 +231,30 @@ class ResourceManager(ABC):
         # Otherwise, return the allocations
         return allocations
 
+    def allocate_grouped_single_node(self, cpus: int, memory: int) -> List[Optional[ResourceAllocation]]:
+        """
+        Check available resources to allocate job request to a single allocation (on a single node) with all resources.
+
+        Parameters
+        ----------
+            cpus: Total number of CPUs requested
+            memory: Amount of memory required in bytes
+
+        Returns
+        -------
+        List[Optional[ResourceAllocation]]
+            List containing a single element, where this element is either a ::class:`ResourceAllocation` if allocation
+            was successful, or ``None``.
+        """
+        self.validate_allocation_parameters(cpus, memory)
+
+        for r in self.get_useable_resources():
+            if r.cpu_count >= cpus and r.memory >= memory:
+                alloc = self.allocate_resource(resource_id=r.resource_id, requested_cpus=cpus, requested_memory=memory)
+                if alloc is not None:
+                    return [alloc]
+        return [None]
+
     def allocate_round_robin(self, cpus: int, memory: int) -> List[Optional[ResourceAllocation]]:
         """
             Check available resources on host nodes and allocate in round robin manner even the request

--- a/python/lib/scheduler/dmod/scheduler/scheduler.py
+++ b/python/lib/scheduler/dmod/scheduler/scheduler.py
@@ -659,6 +659,7 @@ class Launcher(SimpleDockerUtil):
                 service_params.user = 'root'
                 # Also adding this for ngen
                 service_params.capabilities_to_add = ['SYS_ADMIN']
+            # TODO: actually impose/enforce resource allocations on created services
             #TODO check for proper service creation, return False if doesn't work
             service = self.create_service(serviceParams=service_params, idx=alloc_index,
                                           docker_cmd_args=self._generate_docker_cmd_args(job, alloc_index))


### PR DESCRIPTION
Adding support for `AllocationParadigm.GROUPED_SINGLE_NODE`.  This represents associating all requested CPU and memory with a single _ResourceAllocation_ object, which eventually translates to a single Docker container with all the CPU/memory.  

This new paradigm is in contrast to the existing values - in particular  _SINGLE_NODE_ - which allocate 1 CPU and identical fractions of memory to `n` _ResourceAllocation_ objects (i.e., 1 CPU and similar portions of memory to each container), where `n` is the total number of requested CPUs.

