### PR TITLE
Add factory method for creating DataDomain

### DIFF
--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -476,7 +476,7 @@ class DataDomain(Serializable):
         The key for each restriction determines the appropriate ::class:`StandardDatasetIndex` for the restriction's
         ``variable`` property via ::method:`StandardDatasetIndex.get_for_name``.
 
-        The restriction property values should either be a single value, a list or a dictionary with exactly two inner
+        The restriction property values should either be a single value, a list, or a dictionary with exactly two inner
         keys.  Single values are converted to one-items lists, then otherwise treated as lists. Lists represent
         discrete restrictions and may be of arbitrary length. Dictionaries represent continuous restrictions and must
         have exactly two elements (see below for valid inner keys and their meaning).  There is also the special case


### PR DESCRIPTION
Adding classmethod to factory create a `DataDomain` from a `DataFormat` and a collection of keyword args representing the constraints of the domain.

This will be used by some GUI work currently being developed, in particular for creating datasets.  However, it stands alone cleanly (and will probably find more general use), so separating it for an easier review process.
