### PR TITLE
Refactor dmod.core using pydantic

### DIFF
--- a/python/lib/core/dmod/core/common/helper_functions.py
+++ b/python/lib/core/dmod/core/common/helper_functions.py
@@ -3,6 +3,8 @@ Provides simple helper functions
 """
 import typing
 import inspect
+import json
+import enum
 
 
 def get_current_function_name(parent_name: bool = None) -> str:
@@ -175,3 +177,26 @@ def merge_dictionaries(first: typing.Mapping = None, second: typing.Mapping = No
     })
 
     return merged_dictionary
+
+
+def _encode_enum_using_name(o):
+    if isinstance(o, dict):
+        return {_encode_enum_using_name(k): _encode_enum_using_name(v) for k, v in o.items()}
+    elif isinstance(o, (set, tuple, list)):
+        return type(o)(_encode_enum_using_name(x) for x in o)
+    elif isinstance(o, enum.Enum):
+        return o.name
+    elif o == str:
+        return "str"
+    elif o == int:
+        return "int"
+    elif o == float:
+        return "float"
+    elif o == typing.Any:
+        return "Any"
+    return o
+
+
+class EnumNamesJSONEncoder(json.JSONEncoder):
+    def encode(self, o):
+        return super().encode(_encode_enum_using_name(o))

--- a/python/lib/core/dmod/core/common/helper_types.py
+++ b/python/lib/core/dmod/core/common/helper_types.py
@@ -1,0 +1,9 @@
+from enum import Enum
+from .mixins import EnumValidateByNameMixIn
+
+
+class PydanticEnum(EnumValidateByNameMixIn, Enum):
+    """
+    Subtypes of this type are validated using their field name when embedded in
+    `pydantic.BaseModel`'s. Additionally, their field names are exposed in pydantic json schemas.
+    """

--- a/python/lib/core/dmod/core/common/mixins.py
+++ b/python/lib/core/dmod/core/common/mixins.py
@@ -27,9 +27,9 @@ class EnumValidateByNameMixIn:
 
     @classmethod
     def validate(cls, v):
-        enum_names = {k.upper(): item for k, item in cls.__members__.items()}
+        enum_names = {k: item for k, item in cls.__members__.items()}
 
-        name = v.name.upper() if isinstance(v, Enum) else str(v).upper()
+        name = v.name if isinstance(v, Enum) else str(v)
         needle = enum_names.get(name)
 
         if needle is None:

--- a/python/lib/core/dmod/core/common/mixins.py
+++ b/python/lib/core/dmod/core/common/mixins.py
@@ -23,7 +23,7 @@ class EnumValidateByNameMixIn:
     def __modify_schema__(cls, field_schema: Dict[str, Any], field: ModelField) -> None:
         # display enum field names as field options
         if "enum" in field_schema:
-            field_schema["enum"] = [f.name for f in field.type_]
+            field_schema["enum"] = [f.name.upper() for f in field.type_]
             field_schema["type"] = "string"
 
     @classmethod
@@ -32,9 +32,9 @@ class EnumValidateByNameMixIn:
 
     @classmethod
     def validate(cls, v):
-        enum_names = {k: item for k, item in cls.__members__.items()}
+        enum_names = {k.upper(): item for k, item in cls.__members__.items()}
 
-        name = v.name if isinstance(v, Enum) else str(v)
+        name = v.name.upper() if isinstance(v, Enum) else str(v).upper()
         needle = enum_names.get(name)
 
         if needle is None:

--- a/python/lib/core/dmod/core/common/mixins.py
+++ b/python/lib/core/dmod/core/common/mixins.py
@@ -1,0 +1,41 @@
+from pydantic.fields import ModelField
+from pprint import pformat
+from enum import Enum
+
+from typing import Any, Dict
+
+# inspiration / code from https://github.com/pydantic/pydantic/issues/598
+class EnumValidateByNameMixIn:
+    """
+    Mixin methods that enable `pydantic` to validate an `enum.Enum` variant using field names.
+
+    `pydantic.BaseModel`'s that embed a subtype of this mixin will expose the subtype's field
+    _names_ as enum members in their json schema. This strays from the default behavior, where enum
+    _values_ are used instead.
+    """
+
+    @classmethod
+    def __modify_schema__(cls, field_schema: Dict[str, Any], field: ModelField) -> None:
+        # display enum field names as field options
+        if "enum" in field_schema:
+            field_schema["enum"] = [f.name for f in field.type_]
+            field_schema["type"] = "string"
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        enum_names = {k.upper(): item for k, item in cls.__members__.items()}
+
+        name = v.name.upper() if isinstance(v, Enum) else str(v).upper()
+        needle = enum_names.get(name)
+
+        if needle is None:
+            error_message = pformat(
+                f"Invalid Enum field. Field {needle!r} is not a member of {set(enum_names)}"
+            )
+            raise ValueError(error_message)
+
+        return needle

--- a/python/lib/core/dmod/core/common/mixins.py
+++ b/python/lib/core/dmod/core/common/mixins.py
@@ -2,7 +2,12 @@ from pydantic.fields import ModelField
 from pprint import pformat
 from enum import Enum
 
-from typing import Any, Dict
+from .helper_functions import EnumNamesJSONEncoder
+
+from typing import Any, Callable, Dict, Optional, Union, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pydantic.typing import AbstractSetIntStr, MappingIntStrAny
 
 # inspiration / code from https://github.com/pydantic/pydantic/issues/598
 class EnumValidateByNameMixIn:
@@ -39,3 +44,37 @@ class EnumValidateByNameMixIn:
             raise ValueError(error_message)
 
         return needle
+
+
+class PydanticSerializeEnum:
+    """Serialize `pydantic.BaseModel` subclass enum fields using their `name` attribute."""
+
+    def json(
+        self,
+        *,
+        include: Optional[Union["AbstractSetIntStr", "MappingIntStrAny"]] = None,
+        exclude: Optional[Union["AbstractSetIntStr", "MappingIntStrAny"]] = None,
+        by_alias: bool = False,
+        skip_defaults: Optional[bool] = None,
+        exclude_unset: bool = False,
+        exclude_defaults: bool = False,
+        exclude_none: bool = False,
+        encoder: Optional[Callable[[Any], Any]] = None,
+        models_as_dict: bool = True,
+        **dumps_kwargs: Any,
+    ) -> str:
+        return super().json(
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            skip_defaults=skip_defaults,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+            encoder=encoder,
+            models_as_dict=models_as_dict,
+            cls=EnumNamesJSONEncoder
+            if "cls" not in dumps_kwargs
+            else dumps_kwargs["cls"],
+            **dumps_kwargs,
+        )

--- a/python/lib/core/dmod/core/dataset.py
+++ b/python/lib/core/dmod/core/dataset.py
@@ -5,13 +5,13 @@ from .exception import DmodRuntimeError
 from datetime import datetime, timedelta
 
 from .serializable import Serializable, ResultIndicator
-from enum import Enum
+from .common.helper_types import PydanticEnum
 from numbers import Number
 from typing import Any, Callable, Dict, FrozenSet, List, Optional, Set, Tuple, Type, Union
 from uuid import UUID, uuid4
 
 
-class DatasetType(Enum):
+class DatasetType(PydanticEnum):
     UNKNOWN = (-1, False, lambda dataset: None)
     OBJECT_STORE = (0, True, lambda dataset: dataset.name)
     FILESYSTEM = (1, True, lambda dataset: dataset.access_location)

--- a/python/lib/core/dmod/core/dataset.py
+++ b/python/lib/core/dmod/core/dataset.py
@@ -801,14 +801,8 @@ class DatasetManager(ABC):
             self._dataset_users[dataset.name].remove(user.uuid)
         return True
 
-    @property
-    def uuid(self) -> UUID:
-        """
-        UUID for this instance.
 
-        Returns
-        -------
-        UUID
-            UUID for this instance.
-        """
-        return self._uuid
+# TODO: refactor dataset module into embedded package (i.e. `dmod/core/dataset`) splitting out types
+# into their own modules.
+# required because `DatasetManager` is defined after `Dataset`
+Dataset.update_forward_refs()

--- a/python/lib/core/dmod/core/dataset.py
+++ b/python/lib/core/dmod/core/dataset.py
@@ -105,12 +105,6 @@ class Dataset(PydanticSerializeEnum, BaseModel, Serializable):
             return value
         return None
 
-    @validator("manager_uuid", "uuid")
-    def create_uuids(cls, v: str):
-        if isinstance(v, UUID):
-            return v
-        return UUID(v)
-
     @root_validator()
     def set_manager_uuid(cls, values) -> dict:
         manager: Optional[DatasetManager] = values["manager"]

--- a/python/lib/core/dmod/core/execution.py
+++ b/python/lib/core/dmod/core/execution.py
@@ -1,8 +1,9 @@
-from enum import Enum
 from typing import Optional
 
+from .common.helper_types import PydanticEnum
 
-class AllocationParadigm(Enum):
+
+class AllocationParadigm(PydanticEnum):
     """
     Representation of the ways compute assets may be combined to fulfill a total required asset amount for a task.
 

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -466,14 +466,10 @@ class DataDomain(PydanticSerializeEnum, BaseModel, Serializable):
 
         return {k: handle_type_map(v) for k, v in values.items()}
 
-    @root_validator()
-    def validate_sufficient_restrictions(cls, values):
-        continuous_restrictions = values.get("continuous_restrictions", [])
-        discrete_restrictions = values.get("discrete_restrictions", [])
-        if len(continuous_restrictions) + len(discrete_restrictions) == 0:
+    def __post_init__(self):
+        if len(self.continuous_restrictions) + len(self.discrete_restrictions) == 0:
             msg = "Cannot create {} without at least one finite continuous or discrete restriction"
-            raise RuntimeError(msg.format(cls.__name__))
-        return values
+            raise RuntimeError(msg.format(self.__name__))
 
     @classmethod
     def factory_init_from_deserialized_json(cls, json_obj: dict):

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -1,12 +1,12 @@
-from enum import Enum
 from datetime import datetime
 
 from .serializable import Serializable
+from .common.helper_types import PydanticEnum
 from numbers import Number
 from typing import Any, Dict, List, Optional, Set, Type, Union
 
 
-class StandardDatasetIndex(Enum):
+class StandardDatasetIndex(PydanticEnum):
 
     UNKNOWN = (-1, Any)
     TIME = (0, datetime)
@@ -34,7 +34,7 @@ class StandardDatasetIndex(Enum):
         return StandardDatasetIndex.UNKNOWN
 
 
-class DataFormat(Enum):
+class DataFormat(PydanticEnum):
     """
     Supported data format types for data needed or produced by workflow execution tasks.
 
@@ -640,7 +640,7 @@ class DataDomain(Serializable):
         return serial
 
 
-class DataCategory(Enum):
+class DataCategory(PydanticEnum):
     """
     The general category values for different data.
     """

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -471,6 +471,9 @@ class DataDomain(PydanticSerializeEnum, BaseModel, Serializable):
             msg = "Cannot create {} without at least one finite continuous or discrete restriction"
             raise RuntimeError(msg.format(self.__name__))
 
+    class Config:
+        allow_population_by_field_name = True
+
     @classmethod
     def factory_init_from_deserialized_json(cls, json_obj: dict):
         try:

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -232,8 +232,14 @@ class ContinuousRestriction(BaseModel, Serializable):
 
         if datetime_ptr is not None:
             # If there is a datetime pattern, then expect begin and end to parse properly to datetime objects
-            values["begin"] = datetime.strptime(values["begin"], datetime_ptr)
-            values["end"] = datetime.strptime(values["end"], datetime_ptr)
+            begin = values["begin"]
+            end = values["end"]
+
+            if not isinstance(begin, datetime):
+                values["begin"] = datetime.strptime(begin, datetime_ptr)
+
+            if not isinstance(end, datetime):
+                values["end"] = datetime.strptime(end, datetime_ptr)
         return values
 
     @root_validator()

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -623,10 +623,7 @@ class TimeRange(ContinuousRestriction):
     """
     Encapsulated representation of a time range.
     """
-
-    def __init__(self, begin: datetime, end: datetime, datetime_pattern: Optional[str] = None, **kwargs):
-        super(TimeRange, self).__init__(variable=StandardDatasetIndex.TIME, begin=begin, end=end,
-                                        datetime_pattern=self.get_datetime_str_format() if datetime_pattern is None else datetime_pattern)
+    variable: StandardDatasetIndex = Field(StandardDatasetIndex.TIME, const=True)
 
 
 class DataRequirement(Serializable):

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -626,23 +626,16 @@ class TimeRange(ContinuousRestriction):
     variable: StandardDatasetIndex = Field(StandardDatasetIndex.TIME, const=True)
 
 
-class DataRequirement(Serializable):
+class DataRequirement(PydanticSerializeEnum, BaseModel, Serializable):
     """
     A definition of a particular data requirement needed for an execution task.
     """
-
-    _KEY_CATEGORY = 'category'
-    """ Serialization dictionary JSON key for ::attribute:`category` property value. """
-    _KEY_DOMAIN = 'domain'
-    """ Serialization dictionary JSON key for ::attribute:`domain_params` property value. """
-    _KEY_FULFILLED_ACCESS_AT = 'fulfilled_access_at'
-    """ Serialization dictionary JSON key for ::attribute:`fulfilled_access_at` property value. """
-    _KEY_FULFILLED_BY = 'fulfilled_by'
-    """ Serialization dictionary JSON key for ::attribute:`fulfilled_by` property value. """
-    _KEY_IS_INPUT = 'is_input'
-    """ Serialization dictionary JSON key for ::attribute:`is_input` property value. """
-    _KEY_SIZE = 'size'
-    """ Serialization dictionary JSON key for ::attribute:`size` property value. """
+    domain: DataDomain
+    is_input: bool = Field(..., description="Whether this represents required input data, as opposed to a requirement for storing output data.")
+    category: DataCategory
+    size: Optional[int]
+    fulfilled_by: Optional[str] = Field(description="The name of the dataset that will fulfill this, if it is known.")
+    fulfilled_access_at: Optional[str] = Field(description="The location at which the fulfilling dataset for this requirement is accessible, if the dataset known.")
 
     @classmethod
     def factory_init_from_deserialized_json(cls, json_obj: dict) -> Optional['DataRequirement']:
@@ -660,129 +653,15 @@ class DataRequirement(Serializable):
             A deserialized ::class:`DataRequirement` instance, or return ``None`` if the JSON is not valid.
         """
         try:
-            domain = DataDomain.factory_init_from_deserialized_json(json_obj[cls._KEY_DOMAIN])
-            category = DataCategory.get_for_name(json_obj[cls._KEY_CATEGORY])
-            is_input = json_obj[cls._KEY_IS_INPUT]
-
-            opt_kwargs_w_defaults = dict()
-            if cls._KEY_FULFILLED_BY in json_obj:
-                opt_kwargs_w_defaults['fulfilled_by'] = json_obj[cls._KEY_FULFILLED_BY]
-            if cls._KEY_SIZE in json_obj:
-                opt_kwargs_w_defaults['size'] = json_obj[cls._KEY_SIZE]
-            if cls._KEY_FULFILLED_ACCESS_AT in json_obj:
-                opt_kwargs_w_defaults['fulfilled_access_at'] = json_obj[cls._KEY_FULFILLED_ACCESS_AT]
-
-            return cls(domain=domain, is_input=is_input, category=category, **opt_kwargs_w_defaults)
+            return cls(**json_obj)
         except:
             return None
-
-    def __eq__(self, other):
-        return self.__class__ == other.__class__ and self.domain == other.domain and self.is_input == other.is_input \
-               and self.category == other.category
 
     def __hash__(self):
         return hash('{}-{}-{}'.format(hash(self.domain), self.is_input, self.category))
 
-    def __init__(self, domain: DataDomain, is_input: bool, category: DataCategory, size: Optional[int] = None,
-                 fulfilled_by: Optional[str] = None, fulfilled_access_at: Optional[str] = None):
-        self._domain = domain
-        self._is_input = is_input
-        self._category = category
-        self._size = size
-        self._fulfilled_by = fulfilled_by
-        self._fulfilled_access_at = fulfilled_access_at
-
-    @property
-    def category(self) -> DataCategory:
-        """
-        The ::class:`DataCategory` of data required.
-
-        Returns
-        -------
-        DataCategory
-            The category of data required.
-        """
-        return self._category
-
-    @property
-    def domain(self) -> DataDomain:
-        """
-        The (restricted) domain of the data that is required.
-
-        Returns
-        -------
-        DataDomain
-            The (restricted) domain of the data that is required.
-        """
-        return self._domain
-
-    @property
-    def fulfilled_access_at(self) -> Optional[str]:
-        """
-        The location at which the fulfilling dataset for this requirement is accessible, if the dataset known.
-
-        Returns
-        -------
-        Optional[str]
-            The location at which the fulfilling dataset for this requirement is accessible, if known, or ``None``
-            otherwise.
-        """
-        return self._fulfilled_access_at
-
-    @fulfilled_access_at.setter
-    def fulfilled_access_at(self, location: str):
-        self._fulfilled_access_at = location
-
-    @property
-    def fulfilled_by(self) -> Optional[str]:
-        """
-        The name of the dataset that will fulfill this, if it is known.
-
-        Returns
-        -------
-        Optional[str]
-            The name of the dataset that will fulfill this, if it is known; ``None`` otherwise.
-        """
-        return self._fulfilled_by
-
-    @fulfilled_by.setter
-    def fulfilled_by(self, name: str):
-        self._fulfilled_by = name
-
-    @property
-    def is_input(self) -> bool:
-        """
-        Whether this represents required input data, as opposed to a requirement for storing output data.
-
-        Returns
-        -------
-        bool
-            Whether this represents required input data.
-        """
-        return self._is_input
-
-    @property
-    def size(self) -> Optional[int]:
-        """
-        The size of the required data, if it is known.
-
-        This is particularly important (though still not strictly required) for an output data requirement; i.e., a
-        requirement to store output data somewhere.
-
-        Returns
-        -------
-        Optional[int]
-            he size of the required data, if it is known, or ``None`` otherwise.
-        """
-        return self._size
+    def to_json(self) -> str:
+        return self.json(by_alias=True, exclude_unset=True)
 
     def to_dict(self) -> Dict[str, Union[str, Number, dict, list]]:
-        serial = {self._KEY_DOMAIN: self.domain.to_dict(), self._KEY_IS_INPUT: self.is_input,
-                  self._KEY_CATEGORY: self.category.name}
-        if self.size is not None:
-            serial[self._KEY_SIZE] = self.size
-        if self.fulfilled_by is not None:
-            serial[self._KEY_FULFILLED_BY] = self.fulfilled_by
-        if self.fulfilled_access_at is not None:
-            serial[self._KEY_FULFILLED_ACCESS_AT] = self.fulfilled_access_at
-        return serial
+        return self.dict(by_alias=True, exclude_unset=True)

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -217,7 +217,7 @@ def _validate_variable_is_known(cls, variable: StandardDatasetIndex) -> Standard
         raise ValueError("Invalid value for {} variable: {}".format(cls.__name__, variable))
     return variable
 
-class ContinuousRestriction(BaseModel, Serializable):
+class ContinuousRestriction(PydanticSerializeEnum, BaseModel, Serializable):
     """
     A filtering component, typically applied as a restriction on a domain, by a continuous range of values of a variable.
     """
@@ -337,7 +337,8 @@ class ContinuousRestriction(BaseModel, Serializable):
             serial["end"] = self.end.strftime(self.datetime_pattern)
         return serial
 
-class DiscreteRestriction(BaseModel, Serializable):
+
+class DiscreteRestriction(PydanticSerializeEnum, BaseModel, Serializable):
     """
     A filtering component, typically applied as a restriction on a domain, by a discrete set of values of a variable.
 

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from pydantic import BaseModel, root_validator, validator, StrictStr, StrictFloat, StrictInt, Field
 from collections import OrderedDict
@@ -337,6 +338,10 @@ class ContinuousRestriction(PydanticSerializeEnum, BaseModel, Serializable):
             serial["end"] = self.end.strftime(self.datetime_pattern)
         return serial
 
+    def to_json(self) -> str:
+        serial = self.to_dict()
+        serial["variable"] = serial["variable"].name
+        return json.dumps(serial)
 
 class DiscreteRestriction(PydanticSerializeEnum, BaseModel, Serializable):
     """

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -545,30 +545,6 @@ class DataDomain(PydanticSerializeEnum, BaseModel, Serializable):
             return True
 
     @property
-    def continuous_restrictions(self) -> Dict[StandardDatasetIndex, ContinuousRestriction]:
-        """
-        Map of the continuous restrictions defining this domain, keyed by variable name.
-
-        Returns
-        -------
-        Dict[str, ContinuousRestriction]
-            Map of the continuous restrictions defining this domain, keyed by variable name.
-        """
-        return self._continuous_restrictions
-
-    @property
-    def discrete_restrictions(self) -> Dict[StandardDatasetIndex, DiscreteRestriction]:
-        """
-        Map of the discrete restrictions defining this domain, keyed by variable name.
-
-        Returns
-        -------
-        Dict[str, DiscreteRestriction]
-            Map of the discrete restrictions defining this domain, keyed by variable name.
-        """
-        return self._discrete_restrictions
-
-    @property
     def data_fields(self) -> Dict[str, Type]:
         """
         Get the data fields map of this domain instance.

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -582,11 +582,29 @@ class DataDomain(PydanticSerializeEnum, BaseModel, Serializable):
         """
         return self.data_format.indices
 
-    def to_json(self) -> str:
-        if self.data_format.data_fields is None:
-            return self.json(by_alias=True)
+    def dict(self, **kwargs) -> dict:
+        """
+        fields alias names are used by default (`by_alias=True`).
 
-        return self.json(by_alias=True, exclude={"custom_data_fields"})
+        `data_fields` is excluded from dict if `self.data_format.data_fields` is None.
+        """
+        by_alias = kwargs.pop("by_alias") if "by_alias" in kwargs else True
+
+        if self.data_format.data_fields is None:
+            return super().dict(by_alias=by_alias, **kwargs)
+
+        exclude = {"custom_data_fields"}
+
+        # merge exclude fields and excludes from kwargs
+        if "exclude" in kwargs:
+            values = kwargs.pop("exclude")
+            if values is not None:
+                exclude = {*exclude, *values}
+
+        return super().dict(by_alias=by_alias, exclude=exclude, **kwargs)
+
+    def to_json(self) -> str:
+        return self.json(by_alias=True)
 
     def to_dict(self) -> Dict[str, Union[str, Number, dict, list]]:
         """
@@ -599,10 +617,7 @@ class DataDomain(PydanticSerializeEnum, BaseModel, Serializable):
         -------
 
         """
-        if self.data_format.data_fields is None:
-            return self.dict(by_alias=True)
-
-        return self.dict(by_alias=True, exclude={"custom_data_fields"})
+        return self.dict(by_alias=True)
 
 
 class DataCategory(PydanticEnum):

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -210,6 +210,10 @@ class DataFormat(PydanticEnum):
         """
         return self._is_time_series_index
 
+def _validate_variable_is_known(cls, variable: StandardDatasetIndex) -> StandardDatasetIndex:
+    if variable == StandardDatasetIndex.UNKNOWN:
+        raise ValueError("Invalid value for {} variable: {}".format(cls.__name__, variable))
+    return variable
 
 class ContinuousRestriction(BaseModel, Serializable):
     """
@@ -237,11 +241,8 @@ class ContinuousRestriction(BaseModel, Serializable):
 
         return values
 
-    @validator("variable")
-    def validate_variable_is_known(cls, variable):
-        if variable == StandardDatasetIndex.UNKNOWN:
-            raise ValueError("Invalid value for {} variable: {}".format(cls.__name__, variable))
-        return variable
+    # validate variable is not UNKNOWN variant
+    _validate_variable = validator("variable", allow_reuse=True)(_validate_variable_is_known)
 
     @classmethod
     def convert_truncated_serial_form(cls, truncated_json_obj: dict, datetime_format: Optional[str] = None) -> dict:

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -1,5 +1,6 @@
 from datetime import datetime
-from pydantic import BaseModel, root_validator, validator
+from pydantic import BaseModel, root_validator, validator, StrictStr, StrictFloat, StrictInt
+from collections import OrderedDict
 
 from .serializable import Serializable
 from .common.helper_types import PydanticEnum
@@ -329,43 +330,35 @@ class ContinuousRestriction(BaseModel, Serializable):
             serial["end"] = self.end.strftime(self.datetime_pattern)
         return serial
 
-
-class DiscreteRestriction(Serializable):
+class DiscreteRestriction(BaseModel, Serializable):
     """
     A filtering component, typically applied as a restriction on a domain, by a discrete set of values of a variable.
 
     Note that an empty list for the ::attribute:`values` property implies a restriction of all possible values being
     required.  This is reflected by the :method:`is_all_possible_values` property.
     """
+    variable: StandardDatasetIndex
+    values: Union[List[StrictStr], List[StrictFloat], List[StrictInt]]
+
+    # validate variable is not UNKNOWN variant
+    _validate_variable = validator("variable", allow_reuse=True)(_validate_variable_is_known)
+
     @classmethod
     def factory_init_from_deserialized_json(cls, json_obj: dict):
         try:
-            variable = StandardDatasetIndex.get_for_name(json_obj["variable"])
-            if variable == StandardDatasetIndex.UNKNOWN:
-                return None
-            return cls(variable=variable, values=json_obj["values"])
+            return cls(**json_obj)
         except:
             return None
 
-    def __init__(self, variable: Union[str, StandardDatasetIndex], values: Union[List[str], List[Number]], allow_reorder: bool = True,
-                 remove_duplicates: bool = True):
-        self.variable = StandardDatasetIndex.get_for_name(variable) if isinstance(variable, str) else variable
-        if self.variable == StandardDatasetIndex.UNKNOWN:
-            raise ValueError("Invalid value for {} variable: {}".format(self.__class__.__name__, variable))
-        self.values: Union[List[str], List[Number]] = list(set(values)) if remove_duplicates else values
+    def __init__(self, *, allow_reorder: bool = True, remove_duplicates: bool = True, **data: Any) -> None:
+        super().__init__(**data)
+        if remove_duplicates:
+            self.values = list(OrderedDict.fromkeys(self.values))
         if allow_reorder:
             self.values.sort()
 
-    def __eq__(self, other):
-        if self.__class__ == other.__class__ or isinstance(other, self.__class__):
-            return self.variable == other.variable and self.values == other.values
-        elif isinstance(self, other.__class__):
-            return other.__eq__(self)
-        else:
-            return False
-
     def __hash__(self):
-        hash('{}-{}'.format(self.variable.name, ','.join([str(v) for v in self.values])))
+        return hash('{}-{}'.format(self.variable.name, ','.join([str(v) for v in self.values])))
 
     def contains(self, other: 'DiscreteRestriction') -> bool:
         """
@@ -421,8 +414,7 @@ class DiscreteRestriction(Serializable):
         return self.values is not None and len(self.values) == 0
 
     def to_dict(self) -> Dict[str, Union[str, Number, dict, list]]:
-        return {"variable": self.variable.name, "values": self.values}
-
+        return self.dict()
 
 class DataDomain(Serializable):
     """

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -1,9 +1,10 @@
 from datetime import datetime
-from pydantic import BaseModel, root_validator, validator, StrictStr, StrictFloat, StrictInt
+from pydantic import BaseModel, root_validator, validator, StrictStr, StrictFloat, StrictInt, Field
 from collections import OrderedDict
 
 from .serializable import Serializable
 from .common.helper_types import PydanticEnum
+from .common.mixins import PydanticSerializeEnum
 from numbers import Number
 from typing import Any, Dict, List, Optional, Set, Type, Union
 

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -439,9 +439,11 @@ class DataDomain(PydanticSerializeEnum, BaseModel, Serializable):
         description="The format for the data in this domain, which contains details like the indices and other data fields."
     )
     continuous_restrictions: Optional[List[ContinuousRestriction]] = Field(
+        alias="continuous",
         default_factory=list
     )
     discrete_restrictions: Optional[List[DiscreteRestriction]] = Field(
+        alias="discrete",
         default_factory=list
     )
     custom_data_fields: Optional[Dict[str, Union[str, int, float, Any]]] = Field(

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from pydantic import BaseModel, root_validator, validator
 
 from .serializable import Serializable
 from .common.helper_types import PydanticEnum
@@ -210,10 +211,37 @@ class DataFormat(PydanticEnum):
         return self._is_time_series_index
 
 
-class ContinuousRestriction(Serializable):
+class ContinuousRestriction(BaseModel, Serializable):
     """
     A filtering component, typically applied as a restriction on a domain, by a continuous range of values of a variable.
     """
+    variable: StandardDatasetIndex
+    begin: datetime
+    end: datetime
+    datetime_pattern: Optional[str]
+
+    @root_validator(pre=True)
+    def coerce_times_if_datetime_pattern(cls, values):
+        datetime_ptr = values.get("datetime_pattern")
+
+        if datetime_ptr is not None:
+            # If there is a datetime pattern, then expect begin and end to parse properly to datetime objects
+            values["begin"] = datetime.strptime(values["begin"], datetime_ptr)
+            values["end"] = datetime.strptime(values["end"], datetime_ptr)
+        return values
+
+    @root_validator()
+    def validate_start_before_end(cls, values):
+        if values["begin"] > values["end"]:
+            raise RuntimeError("Cannot have {} with begin value larger than end.".format(cls.__name__))
+
+        return values
+
+    @validator("variable")
+    def validate_variable_is_known(cls, variable):
+        if variable == StandardDatasetIndex.UNKNOWN:
+            raise ValueError("Invalid value for {} variable: {}".format(cls.__name__, variable))
+        return variable
 
     @classmethod
     def convert_truncated_serial_form(cls, truncated_json_obj: dict, datetime_format: Optional[str] = None) -> dict:
@@ -250,61 +278,25 @@ class ContinuousRestriction(Serializable):
 
     @classmethod
     def factory_init_from_deserialized_json(cls, json_obj: dict):
-        datetime_ptr = json_obj["datetime_pattern"] if "datetime_pattern" in json_obj else None
-        try:
-            variable = StandardDatasetIndex.get_for_name(json_obj['variable'])
-            if variable == StandardDatasetIndex.UNKNOWN:
-                raise RuntimeError(
-                    "Unrecognized continuous restriction serialize variable: {}".format(json_obj['variable']))
-            # Handle simple case, which currently means non-datetime item (i.e., no pattern included)
-            if datetime_ptr is None:
-                return cls(variable=variable, begin=json_obj["begin"], end=json_obj["end"])
-
-            # If there is a datetime pattern, then expect begin and end to parse properly to datetime objects
-            begin = datetime.strptime(json_obj["begin"], datetime_ptr)
-            end = datetime.strptime(json_obj["end"], datetime_ptr)
-
-            # Use this type if that's what the JSON specifies is the Serializable subtype
-            if cls.__name__ == json_obj["subclass"]:
-                return cls(variable=variable, begin=begin, end=end, datetime_pattern=datetime_ptr)
-
-            # Try to initialize the right subclass type, or fall back if appropriate to the base type
-            # TODO: consider adding something for recursive search for subclass, not just immediate children types
-            # Use nested try, because we want to fall back to cls type if no subclass attempt or subclass attempt fails
+        # Try to initialize the right subclass type, or fall back if appropriate to the base type
+        # TODO: consider adding something for recursive search for subclass, not just immediate children types
+        # Use nested try, because we want to fall back to cls type if no subclass attempt or subclass attempt fails
+        if "subclass" in json_obj:
             try:
                 for subclass in cls.__subclasses__():
                     if subclass.__name__ == json_obj["subclass"]:
-                        return subclass(variable=variable, begin=begin, end=end, datetime_pattern=datetime_ptr)
+                        return subclass(**json_obj)
             except:
                 pass
 
-            # Fall back if needed
-            return cls(variable=variable, begin=begin, end=end, datetime_pattern=datetime_ptr)
+        try:
+            return cls(**json_obj)
         except:
+            # TODO: revisit returning None.
             return None
 
-    def __init__(self, variable: Union[str, StandardDatasetIndex], begin, end, datetime_pattern: Optional[str] = None):
-        self.variable = StandardDatasetIndex.get_for_name(variable) if isinstance(variable, str) else variable
-        if self.variable == StandardDatasetIndex.UNKNOWN:
-            raise ValueError("Invalid value for {} variable: {}".format(self.__class__.__name__, variable))
-        if begin > end:
-            raise RuntimeError("Cannot have {} with begin value larger than end.".format(self.__class__.__name__))
-        self.begin = begin
-        self.end = end
-        self._datetime_pattern = datetime_pattern
-
-    def __eq__(self, other):
-        if self.__class__ == other.__class__ or isinstance(other, self.__class__):
-            return self.variable == other.variable and self.begin == other.begin and self.end == other.end \
-                   and self._datetime_pattern == other._datetime_pattern
-        elif isinstance(self, other.__class__):
-            return other.__eq__(self)
-        else:
-            return False
-
-    def __hash__(self):
-        str_func = lambda x: str(x) if self._datetime_pattern is None else datetime.strptime(x, self._datetime_pattern)
-        hash('{}-{}-{}'.format(self.variable.name, str_func(self.begin), str_func(self.end)))
+    def __hash__(self) -> int:
+        return hash('{}-{}-{}'.format(self.variable.name, self.begin, self.end))
 
     def contains(self, other: 'ContinuousRestriction') -> bool:
         """
@@ -329,16 +321,11 @@ class ContinuousRestriction(Serializable):
            return self.begin <= other.begin and self.end >= other.end
 
     def to_dict(self) -> Dict[str, Union[str, Number, dict, list]]:
-        serial = dict()
-        serial["variable"] = self.variable.name
+        serial = self.dict(exclude_none=True)
         serial["subclass"] = self.__class__.__name__
-        if self._datetime_pattern is not None:
-            serial["datetime_pattern"] = self._datetime_pattern
-            serial["begin"] = self.begin.strftime(self._datetime_pattern)
-            serial["end"] = self.end.strftime(self._datetime_pattern)
-        else:
-            serial["begin"] = self.begin
-            serial["end"] = self.end
+        if self.datetime_pattern is not None:
+            serial["begin"] = self.begin.strftime(self.datetime_pattern)
+            serial["end"] = self.end.strftime(self.datetime_pattern)
         return serial
 
 

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -299,11 +299,11 @@ class ContinuousRestriction(PydanticSerializeEnum, BaseModel, Serializable):
             except:
                 pass
 
-        try:
-            return cls(**json_obj)
-        except:
-            # TODO: revisit returning None.
-            return None
+        # try:
+        return cls(**json_obj)
+        # except:
+        #     # TODO: revisit returning None.
+        #     return None
 
     def __hash__(self) -> int:
         return hash('{}-{}-{}'.format(self.variable.name, self.begin, self.end))
@@ -466,10 +466,14 @@ class DataDomain(PydanticSerializeEnum, BaseModel, Serializable):
 
         return {k: handle_type_map(v) for k, v in values.items()}
 
-    def __post_init__(self):
-        if len(self.continuous_restrictions) + len(self.discrete_restrictions) == 0:
+    @root_validator()
+    def validate_sufficient_restrictions(cls, values):
+        continuous_restrictions = values.get("continuous_restrictions", [])
+        discrete_restrictions = values.get("discrete_restrictions", [])
+        if len(continuous_restrictions) + len(discrete_restrictions) == 0:
             msg = "Cannot create {} without at least one finite continuous or discrete restriction"
-            raise RuntimeError(msg.format(self.__name__))
+            raise RuntimeError(msg.format(cls.__name__))
+        return values
 
     class Config:
         allow_population_by_field_name = True

--- a/python/lib/core/dmod/core/serializable.py
+++ b/python/lib/core/dmod/core/serializable.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from numbers import Number
-from typing import Callable, Dict, Type, Union
+from typing import Callable, Dict, Type, Union, Optional
+from pydantic import BaseModel, Field
 import json
 
 
@@ -213,7 +214,7 @@ class SerializedDict(Serializable):
         return self.base_dict
 
 
-class ResultIndicator(Serializable, ABC):
+class ResultIndicator(BaseModel, Serializable, ABC):
     """
     A type extending from ::class:`Serializable` for encapsulating a status indication for a result of something.
 
@@ -236,18 +237,12 @@ class ResultIndicator(Serializable, ABC):
         An optional, more detailed explanation of the result, which by default is an empty string.
 
     """
-
-    def __init__(self, success: bool, reason: str, message: str = '', *args, **kwargs):
-        super(ResultIndicator, self).__init__(*args, **kwargs)
-        self.success: bool = success
-        """ Whether this indicates a successful result. """
-        self.reason: str = reason
-        """ A very short, high-level summary of the result. """
-        self.message: str = message
-        """ An optional, more detailed explanation of the result, which by default is an empty string. """
+    success: bool = Field(description="Whether this indicates a successful result.")
+    reason: str = Field(description="A very short, high-level summary of the result.")
+    message: Optional[str] = Field("", description="An optional, more detailed explanation of the result, which by default is an empty string.")
 
     def to_dict(self) -> dict:
-        return {'success': self.success, 'reason': self.reason, 'message': self.message}
+        return self.dict()
 
 
 class BasicResultIndicator(ResultIndicator):
@@ -258,9 +253,6 @@ class BasicResultIndicator(ResultIndicator):
     @classmethod
     def factory_init_from_deserialized_json(cls, json_obj: dict):
         try:
-            return cls(success=json_obj['success'], reason=json_obj['reason'], message=json_obj['message'])
+            return cls(**json_obj)
         except Exception as e:
             return None
-
-    def __init__(self, *args, **kwargs):
-        super(BasicResultIndicator, self).__init__(*args, **kwargs)

--- a/python/lib/core/dmod/test/test_dataset.py
+++ b/python/lib/core/dmod/test/test_dataset.py
@@ -155,9 +155,20 @@ class TestDataset(unittest.TestCase):
 
     def test_to_json(self):
         import json
-        o = Dataset(name="some_data", type=DatasetType.OBJECT_STORE, access_location="here", data_category="CONFIG")
-        from pprint import pprint
-        pprint(json.loads(o.to_json()))
+
+        valid_data = {
+        "name": "some_data",
+        "type": "OBJECT_STORE",
+        "access_location": "here",
+        "data_category": "CONFIG",
+        "uuid": "00000000-0000-0000-0000-000000000000"
+        }
+        s_json = json.loads(
+            Dataset(**valid_data).to_json()
+        )
+        for k, v in valid_data.items():
+            self.assertEqual(s_json[k], v)
+
 
     def test_factory_init_from_deserialized_json_back_to_dict_1_a(self):
         """ Test basic operation of function on example 1. """

--- a/python/lib/core/dmod/test/test_meta_data.py
+++ b/python/lib/core/dmod/test/test_meta_data.py
@@ -1,0 +1,166 @@
+import unittest
+from datetime import datetime
+
+from dmod.core.meta_data import (
+    ContinuousRestriction,
+    DiscreteRestriction,
+    StandardDatasetIndex,
+    DataDomain,
+    DataFormat,
+)
+
+from typing import Any
+
+
+class TestContinuousRestriction(unittest.TestCase):
+    def test_custom_datetime_pattern(self):
+        o = ContinuousRestriction(
+            begin="2020-01-01",
+            end="2020-01-02",
+            variable="TIME",
+            datetime_pattern="%Y-%m-%d",
+        )
+        self.assertEqual(o.variable, StandardDatasetIndex.TIME)
+
+    def test_custom_datetime_pattern_should_fail(self):
+        with self.assertRaises(RuntimeError):
+            ContinuousRestriction(
+                begin="2020-01-01",
+                end="2019-12-31",
+                variable="TIME",
+                datetime_pattern="%Y-%m-%d",
+            )
+
+    def test_create_from_python_objects(self):
+        begin = datetime(2020, 1, 1)
+        end = datetime(2020, 1, 2)
+        o = ContinuousRestriction(
+            begin=begin, end=end, variable=StandardDatasetIndex.TIME
+        )
+        self.assertEqual(o.begin, begin)
+        self.assertEqual(o.end, end)
+        self.assertEqual(o.variable, StandardDatasetIndex.TIME)
+
+    def test_create_fails_with_invalid_variable(self):
+        begin = datetime(2020, 1, 1)
+        end = datetime(2020, 1, 2)
+        with self.assertRaises(ValueError):
+            ContinuousRestriction(
+                begin=begin, end=end, variable=StandardDatasetIndex.UNKNOWN
+            )
+
+    def test_eq(self):
+        begin = datetime(2020, 1, 1)
+        end = datetime(2020, 1, 2)
+        o1 = ContinuousRestriction(
+            begin=begin, end=end, variable=StandardDatasetIndex.TIME
+        )
+        o2 = ContinuousRestriction(
+            begin=begin, end=end, variable=StandardDatasetIndex.TIME
+        )
+
+        self.assertEqual(o1, o2)
+
+    def test_hash(self):
+        begin = datetime(2020, 1, 1)
+        end = datetime(2020, 1, 2)
+        var = StandardDatasetIndex.TIME
+        expected_hash = hash(f"{var.name}-{begin}-{end}")
+        o_hash = hash(ContinuousRestriction(variable=var, begin=begin, end=end))
+        self.assertEqual(expected_hash, o_hash)
+
+    def test_to_dict(self):
+        begin = "2020-01-01"
+        end = "2020-01-02"
+        d = ContinuousRestriction(
+            begin=begin,
+            end=end,
+            variable="TIME",
+            datetime_pattern="%Y-%m-%d",
+        ).to_dict()
+        self.assertEqual(d["begin"], begin)
+        self.assertEqual(d["end"], end)
+        self.assertEqual(d["variable"], StandardDatasetIndex.TIME)
+
+    def test_factory_init_from_deserialized_json(self):
+        deserialied = {"begin": 0, "end": 1, "variable": "TIME"}
+        o1 = ContinuousRestriction.factory_init_from_deserialized_json(deserialied)
+
+        deserialied = {
+            "begin": 0,
+            "end": 1,
+            "variable": "TIME",
+            "subclass": "ContinuousRestriction",
+        }
+        o2 = ContinuousRestriction.factory_init_from_deserialized_json(deserialied)
+        self.assertEqual(o1, o2)
+
+
+class TestDiscreteRestriction(unittest.TestCase):
+    def test_duplicate_values_removed(self):
+        o = DiscreteRestriction(
+            variable="TIME", values=[1, 1, 1], remove_duplicates=True
+        )
+        self.assertListEqual(o.values, [1])
+
+    def test_values_reordered(self):
+        values = [3, 2, 1]
+        o = DiscreteRestriction(variable="TIME", values=values, allow_reorder=True)
+        self.assertListEqual(o.values, values[::-1])
+
+    def test_values_removed_not_reordered(self):
+        values = [3, 3, 2, 1]
+        o = DiscreteRestriction(
+            variable="TIME",
+            values=values,
+            allow_reorder=False,
+            remove_duplicates=True,
+        )
+        self.assertListEqual(o.values, values[1:])
+
+    def test_values_reordered_not_removed(self):
+        values = [3, 3, 2, 1]
+        o = DiscreteRestriction(
+            variable="TIME",
+            values=values,
+            allow_reorder=True,
+            remove_duplicates=False,
+        )
+        self.assertListEqual(o.values, values[::-1])
+
+
+class TestDataDomain(unittest.TestCase):
+    def test_it_works(self):
+        disc_rest = DiscreteRestriction(
+            variable=StandardDatasetIndex.DATA_ID, values=["0"]
+        )
+        o = DataDomain(
+            data_format=DataFormat.AORC_CSV,
+            discrete_restrictions=[disc_rest],
+            data_fields=dict(a="str", b="float", c="int", d="datetime"),
+        )
+        self.assertEqual(o.custom_data_fields["a"], str)
+        self.assertEqual(o.custom_data_fields["b"], float)
+        self.assertEqual(o.custom_data_fields["c"], int)
+        self.assertEqual(o.custom_data_fields["d"], Any)
+        print(o.to_json())
+
+    def test_init_fails_if_insufficient_restrictions(self):
+        with self.assertRaises(RuntimeError):
+            DataDomain(
+                data_format=DataFormat.AORC_CSV,
+                continuous_restrictions=[],
+                discrete_restrictions=[],
+            )
+
+        with self.assertRaises(RuntimeError):
+            DataDomain(data_format=DataFormat.AORC_CSV)
+
+    def test_factory_init_from_deserialized_json(self):
+        data = {
+            "data_format": "AORC_CSV",
+            "continuous_restrictions": [],
+            "discrete_restrictions": [{"variable": "DATA_ID", "values": ["0"]}],
+        }
+        o = DataDomain.factory_init_from_deserialized_json(data)
+        self.assertEqual(o.data_format.name, "AORC_CSV")

--- a/python/lib/core/dmod/test/test_meta_data.py
+++ b/python/lib/core/dmod/test/test_meta_data.py
@@ -7,6 +7,7 @@ from dmod.core.meta_data import (
     StandardDatasetIndex,
     DataDomain,
     DataFormat,
+    TimeRange,
 )
 
 from typing import Any
@@ -143,7 +144,6 @@ class TestDataDomain(unittest.TestCase):
         self.assertEqual(o.custom_data_fields["b"], float)
         self.assertEqual(o.custom_data_fields["c"], int)
         self.assertEqual(o.custom_data_fields["d"], Any)
-        print(o.to_json())
 
     def test_init_fails_if_insufficient_restrictions(self):
         with self.assertRaises(RuntimeError):
@@ -164,3 +164,13 @@ class TestDataDomain(unittest.TestCase):
         }
         o = DataDomain.factory_init_from_deserialized_json(data)
         self.assertEqual(o.data_format.name, "AORC_CSV")
+
+
+class TestTimeRange(unittest.TestCase):
+    def test_begin_cannot_come_after_end(self):
+        with self.assertRaises(RuntimeError):
+            TimeRange(begin=1, end=0)
+
+    def test_cannot_provide_non_time_variable(self):
+        with self.assertRaises(RuntimeError):
+            TimeRange(variable=StandardDatasetIndex.DATA_ID, begin=1, end=0)

--- a/python/lib/core/dmod/test/test_meta_data.py
+++ b/python/lib/core/dmod/test/test_meta_data.py
@@ -8,6 +8,8 @@ from dmod.core.meta_data import (
     DataDomain,
     DataFormat,
     TimeRange,
+    DataCategory,
+    DataRequirement,
 )
 
 from typing import Any
@@ -174,3 +176,20 @@ class TestTimeRange(unittest.TestCase):
     def test_cannot_provide_non_time_variable(self):
         with self.assertRaises(RuntimeError):
             TimeRange(variable=StandardDatasetIndex.DATA_ID, begin=1, end=0)
+
+class TestDataRequirement(unittest.TestCase):
+    def test_unset_fields_are_excluded_in_serialized_dict(self):
+        domain = DataDomain(
+            data_format=DataFormat.AORC_CSV,
+            discrete_restrictions=[
+                DiscreteRestriction(variable=StandardDatasetIndex.DATA_ID, values=["0"])
+            ],
+        )
+
+        d = DataRequirement(
+            domain=domain, is_input=True, category=DataCategory.CONFIG
+        ).to_dict()
+        self.assertNotIn("size", d)
+        self.assertNotIn("fulfilled_by", d)
+        self.assertNotIn("fulfilled_access_at", d)
+

--- a/python/lib/core/dmod/test/test_mixins.py
+++ b/python/lib/core/dmod/test/test_mixins.py
@@ -1,0 +1,36 @@
+import unittest
+import enum
+from pydantic import BaseModel
+
+from dmod.core.common.mixins import EnumValidateByNameMixIn
+
+
+class SomeEnum(EnumValidateByNameMixIn, enum.Enum):
+    foo = 1
+    bar = 2
+    baz = 3
+
+
+class SomeModel(BaseModel):
+    some_enum: SomeEnum
+
+
+class TestEnumValidateByNameMixIn(unittest.TestCase):
+    def test_instantiate_model_with_enum_field_name(self):
+        model = SomeModel(some_enum="foo")
+        self.assertEqual(model.some_enum, SomeEnum.foo)
+
+    def test_instantiate_model_with_enum_instance(self):
+        model = SomeModel(some_enum=SomeEnum.foo)
+        self.assertEqual(model.some_enum, SomeEnum.foo)
+
+    def test_raises_ValueError_instantiate_model_with_bad_enum_field_name(self):
+        with self.assertRaises(ValueError):
+            SomeModel(some_enum="missing_field")
+
+    def test_raises_ValueError_instantiate_model_with_bad_enum_instance(self):
+        class BadEnum(enum.Enum):
+            bad = 1
+
+        with self.assertRaises(ValueError):
+            SomeModel(some_enum=BadEnum.bad)

--- a/python/lib/core/dmod/test/test_mixins.py
+++ b/python/lib/core/dmod/test/test_mixins.py
@@ -34,3 +34,11 @@ class TestEnumValidateByNameMixIn(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             SomeModel(some_enum=BadEnum.bad)
+
+    def test_enum_names_in_json_schema(self):
+        schema = SomeModel.schema()
+        some_enum_schema = schema["definitions"]["SomeEnum"]
+        self.assertEqual(some_enum_schema["type"], "string")
+
+        enum_field_names = [member.name for member in SomeEnum]
+        self.assertListEqual(enum_field_names, some_enum_schema["enum"])

--- a/python/lib/core/setup.py
+++ b/python/lib/core/setup.py
@@ -14,6 +14,6 @@ setup(
     author_email='',
     url='',
     license='',
-    install_requires=[],
+    install_requires=["pydantic"],
     packages=find_namespace_packages(exclude=('tests', 'schemas', 'ssl', 'src'))
 )


### PR DESCRIPTION
The main goals of this PR are to improve code readability and simplify and offload type coercion and validation to `pydantic`. 

This PR refactors how the `core` package's enums and `Serializable` subtypes are serialized, deserialized, and validated. As the title suggests, the major change in this PR is the introduction of [`pydantic`](https://docs.pydantic.dev/) to handle the tasks of serialization, deserialization, and validation. 

This PR is nearly be one-to-one feature compliant.~, however there are some small changes in how dictionaries and enums are handled that could affect other portions of the code base.~ 

1. ~`to_dict` now returns all enums as enum instances.~
2. ~`to_json` always returns enums encoded using their `name` attribute.~

Prior to this PR, `to_dict`'s behavior was not consistent across subtypes of `Serializable`. Generally enums would be returned using an instance of an enum type, but in other cases the enum's `name` attribute was returned as a `str`. This will cause issues if you try to `json.dumps` a dictionary with an enum instance that does not take a secondary subtype of `int` or `str` (i.e. `StrEnum(str, Enum):`). This however does not affect `factory_init_from_deserialized_json`. Across all subtypes, the method is now more robust and in the case of enums, accepts either an enums `name` attribute or enum instance.

## Changes

- ~`Serializable` subtypes `to_dict` now returns all enums as enum instances.~
- ~`Serializable` subtypes `to_json` always returns enums encoded using their `name` attribute.~

## Testing

1. `meta_data` module unittests added
2. `dataset` unittests added. more json deserialization tests should be added in the future.

## Todos

- [ ] bump `dmod.core` version prior to merge.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: