### PR TITLE
(Resubmit of #230) Fix setup.py readme and version path references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 .env
 docker/main/base/ssh/
 python/gui/db.sqlite3
+dist/
+build/
+*.egg-info/
 
 /.dmod_client_config.yml
 

--- a/python/lib/access/setup.py
+++ b/python/lib/access/setup.py
@@ -1,12 +1,15 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
 
 try:
-    with open('README.md', 'r') as readme:
+    with open(ROOT / 'README.md', 'r') as readme:
         long_description = readme.read()
 except:
     long_description = ''
 
-exec(open('dmod/access/_version.py').read())
+exec(open(ROOT / 'dmod/access/_version.py').read())
 
 setup(
     name='dmod-access',

--- a/python/lib/client/setup.py
+++ b/python/lib/client/setup.py
@@ -1,12 +1,15 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
 
 try:
-    with open('README.md', 'r') as readme:
+    with open(ROOT / 'README.md', 'r') as readme:
         long_description = readme.read()
 except:
     long_description = ''
 
-exec(open('dmod/client/_version.py').read())
+exec(open(ROOT / 'dmod/client/_version.py').read())
 
 setup(
     name='dmod-client',

--- a/python/lib/communication/setup.py
+++ b/python/lib/communication/setup.py
@@ -1,12 +1,15 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
 
 try:
-    with open('README.md', 'r') as readme:
+    with open(ROOT / 'README.md', 'r') as readme:
         long_description = readme.read()
 except:
     long_description = ''
 
-exec(open('dmod/communication/_version.py').read())
+exec(open(ROOT / 'dmod/communication/_version.py').read())
 
 setup(
     name='dmod-communication',

--- a/python/lib/core/setup.py
+++ b/python/lib/core/setup.py
@@ -1,9 +1,15 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
 
-with open('README.md', 'r') as readme:
-    long_description = readme.read()
+ROOT = Path(__file__).resolve().parent
 
-exec(open('dmod/core/_version.py').read())
+try:
+    with open(ROOT / 'README.md', 'r') as readme:
+        long_description = readme.read()
+except:
+    long_description = ''
+
+exec(open(ROOT / 'dmod/core/_version.py').read())
 
 setup(
     name='dmod-core',

--- a/python/lib/evaluations/setup.py
+++ b/python/lib/evaluations/setup.py
@@ -1,12 +1,15 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
 
 try:
-    with open('README.md', 'r') as readme:
+    with open(ROOT / 'README.md', 'r') as readme:
         long_description = readme.read()
 except:
     long_description = ''
 
-exec(open('dmod/evaluations/_version.py').read())
+exec(open(ROOT / 'dmod/evaluations/_version.py').read())
 
 setup(
     name='dmod-evaluations',

--- a/python/lib/externalrequests/setup.py
+++ b/python/lib/externalrequests/setup.py
@@ -1,12 +1,15 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
 
 try:
-    with open('README.md', 'r') as readme:
+    with open(ROOT / 'README.md', 'r') as readme:
         long_description = readme.read()
 except:
     long_description = ''
 
-exec(open('dmod/externalrequests/_version.py').read())
+exec(open(ROOT / 'dmod/externalrequests/_version.py').read())
 
 setup(
     name='dmod-externalrequests',

--- a/python/lib/metrics/setup.py
+++ b/python/lib/metrics/setup.py
@@ -1,12 +1,15 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
 
 try:
-    with open('README.md', 'r') as readme:
+    with open(ROOT / 'README.md', 'r') as readme:
         long_description = readme.read()
 except:
     long_description = ''
 
-exec(open('dmod/metrics/_version.py').read())
+exec(open(ROOT / 'dmod/metrics/_version.py').read())
 
 setup(
     name='dmod-metrics',

--- a/python/lib/modeldata/setup.py
+++ b/python/lib/modeldata/setup.py
@@ -1,9 +1,15 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
 
-with open('README.md', 'r') as readme:
-    long_description = readme.read()
+ROOT = Path(__file__).resolve().parent
 
-exec(open('dmod/modeldata/_version.py').read())
+try:
+    with open(ROOT / 'README.md', 'r') as readme:
+        long_description = readme.read()
+except:
+    long_description = ''
+
+exec(open(ROOT / 'dmod/modeldata/_version.py').read())
 
 setup(
     name='dmod-modeldata',

--- a/python/lib/monitor/setup.py
+++ b/python/lib/monitor/setup.py
@@ -1,12 +1,15 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
 
 try:
-    with open('README.md', 'r') as readme:
+    with open(ROOT / 'README.md', 'r') as readme:
         long_description = readme.read()
 except:
     long_description = ''
 
-exec(open('dmod/monitor/_version.py').read())
+exec(open(ROOT / 'dmod/monitor/_version.py').read())
 
 setup(
     name='dmod-monitor',

--- a/python/lib/redis/setup.py
+++ b/python/lib/redis/setup.py
@@ -1,12 +1,15 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
 
 try:
-    with open('README.md', 'r') as readme:
+    with open(ROOT / 'README.md', 'r') as readme:
         long_description = readme.read()
 except:
     long_description = ''
 
-exec(open('dmod/redis/_version.py').read())
+exec(open(ROOT / 'dmod/redis/_version.py').read())
 
 setup(
     name='dmod-redis',

--- a/python/lib/scheduler/setup.py
+++ b/python/lib/scheduler/setup.py
@@ -1,12 +1,15 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
 
 try:
-    with open('README.md', 'r') as readme:
+    with open(ROOT / 'README.md', 'r') as readme:
         long_description = readme.read()
 except:
     long_description = ''
 
-exec(open('dmod/scheduler/_version.py').read())
+exec(open(ROOT / 'dmod/scheduler/_version.py').read())
 
 setup(
     name='dmod-scheduler',

--- a/python/services/datarequestservice/setup.py
+++ b/python/services/datarequestservice/setup.py
@@ -1,9 +1,12 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
 
-with open('README.md', 'r') as readme:
+ROOT = Path(__file__).resolve().parent
+
+with open(ROOT / 'README.md', 'r') as readme:
     long_description = readme.read()
 
-exec(open('dmod/datarequestservice/_version.py').read())
+exec(open(ROOT / 'dmod/datarequestservice/_version.py').read())
 
 setup(
     name='dmod-datarequestservice',

--- a/python/services/dataservice/setup.py
+++ b/python/services/dataservice/setup.py
@@ -1,9 +1,12 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
 
-with open('README.md', 'r') as readme:
+ROOT = Path(__file__).resolve().parent
+
+with open(ROOT / 'README.md', 'r') as readme:
     long_description = readme.read()
 
-exec(open('dmod/dataservice/_version.py').read())
+exec(open(ROOT / 'dmod/dataservice/_version.py').read())
 
 setup(
     name='dmod-dataservice',

--- a/python/services/evaluationservice/setup.py
+++ b/python/services/evaluationservice/setup.py
@@ -1,9 +1,12 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
 
-with open('README.md', 'r') as readme:
+ROOT = Path(__file__).resolve().parent
+
+with open(ROOT / 'README.md', 'r') as readme:
     long_description = readme.read()
 
-exec(open('dmod/evaluationservice/_version.py').read())
+exec(open(ROOT / 'dmod/evaluationservice/_version.py').read())
 
 setup(
     name='dmod-evaluationservice',

--- a/python/services/monitorservice/setup.py
+++ b/python/services/monitorservice/setup.py
@@ -1,9 +1,12 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
 
-with open('README.md', 'r') as readme:
+ROOT = Path(__file__).resolve().parent
+
+with open(ROOT / 'README.md', 'r') as readme:
     long_description = readme.read()
 
-exec(open('dmod/monitorservice/_version.py').read())
+exec(open(ROOT / 'dmod/monitorservice/_version.py').read())
 
 setup(
     name='dmod-monitorservice',

--- a/python/services/partitionerservice/setup.py
+++ b/python/services/partitionerservice/setup.py
@@ -1,9 +1,12 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
 
-with open('README.md', 'r') as readme:
+ROOT = Path(__file__).resolve().parent
+
+with open(ROOT / 'README.md', 'r') as readme:
     long_description = readme.read()
 
-exec(open('dmod/partitionerservice/_version.py').read())
+exec(open(ROOT / 'dmod/partitionerservice/_version.py').read())
 
 setup(
     name='dmod-partitionerservice',

--- a/python/services/requestservice/setup.py
+++ b/python/services/requestservice/setup.py
@@ -1,9 +1,12 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
 
-with open('README.md', 'r') as readme:
+ROOT = Path(__file__).resolve().parent
+
+with open(ROOT / 'README.md', 'r') as readme:
     long_description = readme.read()
 
-exec(open('dmod/requestservice/_version.py').read())
+exec(open(ROOT / 'dmod/requestservice/_version.py').read())
 
 setup(
     name='dmod-requestservice',

--- a/python/services/schedulerservice/setup.py
+++ b/python/services/schedulerservice/setup.py
@@ -1,9 +1,12 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
 
-with open('README.md', 'r') as readme:
+ROOT = Path(__file__).resolve().parent
+
+with open(ROOT / 'README.md', 'r') as readme:
     long_description = readme.read()
 
-exec(open('dmod/schedulerservice/_version.py').read())
+exec(open(ROOT / 'dmod/schedulerservice/_version.py').read())
 
 setup(
     name='dmod-schedulerservice',

--- a/python/services/subsetservice/setup.py
+++ b/python/services/subsetservice/setup.py
@@ -1,9 +1,12 @@
 from setuptools import setup, find_namespace_packages
+from pathlib import Path
 
-with open('README.md', 'r') as readme:
+ROOT = Path(__file__).resolve().parent
+
+with open(ROOT / 'README.md', 'r') as readme:
     long_description = readme.read()
 
-exec(open('dmod/subsetservice/_version.py').read())
+exec(open(ROOT / 'dmod/subsetservice/_version.py').read())
 
 setup(
     name='dmod-subsetservice',


### PR DESCRIPTION
Rebase of #230 on master to enable merge.

> Subpackage's `setup.py` files now resolve paths to `README.md` and `_version.py` relative to the `setup.py`, instead of where `pip` or `python setup.py install` is called. Enables installing subpackages without changing the current working directory to a subpackage's root (where `setup.py` lives).

https://github.com/NOAA-OWP/DMOD/pull/230#issue-1519389162

closes #230