### PR TITLE
Refactor dmod.modeldata serialization and deserialization types

### DIFF
--- a/python/lib/modeldata/dmod/modeldata/data/object_store_manager.py
+++ b/python/lib/modeldata/dmod/modeldata/data/object_store_manager.py
@@ -560,8 +560,8 @@ class ObjectStoreDatasetManager(DatasetManager):
             response_obj.release_conn()
 
         # If we can safely infer it, make sure the "type" key is set in cases when it is missing
-        if len(self.supported_dataset_types) == 1 and Dataset._KEY_TYPE not in response_data:
-            response_data[Dataset._KEY_TYPE] = list(self.supported_dataset_types)[0].name
+        if len(self.supported_dataset_types) == 1 and "type" not in response_data:
+            response_data["type"] = list(self.supported_dataset_types)[0].name
 
         dataset = Dataset.factory_init_from_deserialized_json(response_data)
         dataset.manager = self

--- a/python/lib/modeldata/dmod/modeldata/hydrofabric/partition.py
+++ b/python/lib/modeldata/dmod/modeldata/hydrofabric/partition.py
@@ -34,8 +34,32 @@ class Partition(Serializable):
             "remote_downstream_nexus_ids": {"alias": "remote-down"},
         }
 
-    def __init__(self, partition_id: int, catchment_ids: Collection[str], nexus_ids: Collection[str],
-                 remote_up_nexuses: Collection[str] = None, remote_down_nexuses: Collection[str] = None, **data):
+        def _serialize_frozenset(value: FrozenSet[str]) -> List[str]:
+            return list(value)
+
+        field_serializers = {
+            "catchment_ids": _serialize_frozenset,
+            "nexus_ids":  _serialize_frozenset,
+            "remote_upstream_nexus_ids":  _serialize_frozenset,
+            "remote_downstream_nexus_ids":  _serialize_frozenset,
+        }
+
+    def __init__(
+            self,
+            # required, but for backwards compatibility, None
+            partition_id: int = None,
+            catchment_ids: Collection[str] = None,
+            nexus_ids: Collection[str] = None,
+            # non-required fields
+            remote_up_nexuses: Collection[str] = None,
+            remote_down_nexuses: Collection[str] = None,
+            **data
+        ):
+        # if data exists, assume fields specified using their alias; no backwards compatibility.
+        if data:
+            super().__init__(**data)
+            return
+
 
         if remote_up_nexuses is None or remote_down_nexuses is None:
             super().__init__(

--- a/python/lib/modeldata/dmod/modeldata/hydrofabric/partition.py
+++ b/python/lib/modeldata/dmod/modeldata/hydrofabric/partition.py
@@ -150,5 +150,5 @@ class PartitionConfig(Serializable):
         int
             Hash of instance
         """
-        return hash(','.join([str(p.__hash__()) for p in sorted(self._partitions)]))
+        return hash(','.join([str(p.__hash__()) for p in sorted(self.partitions)]))
 

--- a/python/lib/modeldata/dmod/modeldata/hydrofabric/partition.py
+++ b/python/lib/modeldata/dmod/modeldata/hydrofabric/partition.py
@@ -30,8 +30,8 @@ class Partition(Serializable):
             "catchment_ids": {"alias": "cat-ids"},
             "partition_id": {"alias": "id"},
             "nexus_ids": {"alias": "nex-ids"},
-            "remote_up_nexuses": {"alias": "remote-up"},
-            "remote_down_nexuses": {"alias": "remote-down"},
+            "remote_upstream_nexus_ids": {"alias": "remote-up"},
+            "remote_downstream_nexus_ids": {"alias": "remote-down"},
         }
 
     def __init__(self, partition_id: int, catchment_ids: Collection[str], nexus_ids: Collection[str],

--- a/python/lib/modeldata/dmod/modeldata/hydrofabric/partition.py
+++ b/python/lib/modeldata/dmod/modeldata/hydrofabric/partition.py
@@ -105,7 +105,7 @@ class PartitionConfig(Serializable):
         if not isinstance(other, PartitionConfig):
             return False
         other_partitions_dict = dict()
-        for other_p in other._partitions:
+        for other_p in other.partitions:
             other_partitions_dict[other_p.partition_id] = other_p
 
         other_pids = set([p2.partition_id for p2 in other.partitions])

--- a/python/lib/modeldata/dmod/modeldata/hydrofabric/partition.py
+++ b/python/lib/modeldata/dmod/modeldata/hydrofabric/partition.py
@@ -118,6 +118,14 @@ class PartitionConfig(Serializable):
     def _sort_partitions(cls, value: FrozenSet[Partition]) -> FrozenSet[Partition]:
         return frozenset(sorted(value))
 
+    class Config:
+        def _serialize_frozenset(value: FrozenSet[Partition]) -> List[Partition]:
+            return list(value)
+
+        field_serializers = {
+                "partitions": _serialize_frozenset
+                }
+
     @classmethod
     def get_serial_property_key_partitions(cls) -> str:
         return "partitions"

--- a/python/lib/modeldata/dmod/modeldata/hydrofabric/partition.py
+++ b/python/lib/modeldata/dmod/modeldata/hydrofabric/partition.py
@@ -1,5 +1,5 @@
-from typing import Collection, Dict, FrozenSet, List, Tuple, Union
-from pydantic import Field, validator
+from typing import Collection, Dict, FrozenSet, List, Optional, Tuple, Union
+from pydantic import Field, PrivateAttr, validator
 from dmod.core.serializable import Serializable
 
 
@@ -23,6 +23,8 @@ class Partition(Serializable):
     remote_upstream_nexus_ids: FrozenSet[str] = Field(default_factory=frozenset)
     remote_downstream_nexus_ids: FrozenSet[str] = Field(default_factory=frozenset)
 
+    _hash_val: Optional[int] = PrivateAttr(None)
+
     class Config:
         fields = {
             "catchment_ids": {"alias": "cat-ids"},
@@ -34,8 +36,6 @@ class Partition(Serializable):
 
     def __init__(self, partition_id: int, catchment_ids: Collection[str], nexus_ids: Collection[str],
                  remote_up_nexuses: Collection[str] = None, remote_down_nexuses: Collection[str] = None, **data):
-
-        self._hash_val = None
 
         if remote_up_nexuses is None or remote_down_nexuses is None:
             super().__init__(

--- a/python/lib/modeldata/dmod/modeldata/subset/hydrofabric_subset.py
+++ b/python/lib/modeldata/dmod/modeldata/subset/hydrofabric_subset.py
@@ -129,13 +129,10 @@ class SimpleHydrofabricSubset(HydrofabricSubset):
         return cls(catchment_ids=subset_def.catchment_ids, nexus_ids=subset_def.nexus_ids, hydrofabric=hydrofabric,
                    *args, **kwargs)
 
-    __slots__ = ["_catchments", "_nexuses"]
-
-    def __init__(self, catchment_ids: Collection[str], nexus_ids: Collection[str], hydrofabric: Hydrofabric, *args,
-                 **kwargs):
+    def __init__(self, catchment_ids: Collection[str], nexus_ids: Collection[str], hydrofabric: Hydrofabric, **data):
         self._catchments: Set[Catchment] = set()
         self._nexuses: Set[Nexus] = set()
-        super().__init__(catchment_ids, nexus_ids, hydrofabric)
+        super().__init__(catchment_ids=catchment_ids, nexus_ids=nexus_ids, hydrofabric=hydrofabric, **data)
         # Since super __init__ validates, and validate function make sure ids are recognized, these won't ever be None
         for cid in catchment_ids:
             self._catchments.add(hydrofabric.get_catchment_by_id(cid))
@@ -186,11 +183,11 @@ class SimpleHydrofabricSubset(HydrofabricSubset):
             otherwise.
         """
         if hydrofabric is None:
-            hydrofabric = self._hydrofabric
-        for cid in self._catchment_ids:
+            hydrofabric = self.hydrofabric
+        for cid in self.catchment_ids:
             if not hydrofabric.is_catchment_recognized(cid):
                 return False
-        for nid in self._nexus_ids:
+        for nid in self.nexus_ids:
             if not hydrofabric.is_nexus_recognized(nid):
                 return False
         return True

--- a/python/lib/modeldata/dmod/modeldata/subset/hydrofabric_subset.py
+++ b/python/lib/modeldata/dmod/modeldata/subset/hydrofabric_subset.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from hypy import Catchment, Nexus
 from typing import Collection, Optional, Set, Tuple
+from pydantic import PrivateAttr
 from ..hydrofabric import Hydrofabric
 from .subset_definition import SubsetDefinition
 
@@ -102,6 +103,9 @@ class SimpleHydrofabricSubset(HydrofabricSubset):
     Simple ::class:`HydrofabricSubset` type.
     """
 
+    _catchments: Set[Catchment] = PrivateAttr(default_factory=set)
+    _nexuses: Set[Nexus] = PrivateAttr(default_factory=set)
+
     @classmethod
     def factory_create_from_base_and_hydrofabric(cls, subset_def: SubsetDefinition, hydrofabric: Hydrofabric,
                                                  *args, **kwargs) \
@@ -130,13 +134,11 @@ class SimpleHydrofabricSubset(HydrofabricSubset):
                    *args, **kwargs)
 
     def __init__(self, catchment_ids: Collection[str], nexus_ids: Collection[str], hydrofabric: Hydrofabric, **data):
-        self._catchments: Set[Catchment] = set()
-        self._nexuses: Set[Nexus] = set()
         super().__init__(catchment_ids=catchment_ids, nexus_ids=nexus_ids, hydrofabric=hydrofabric, **data)
         # Since super __init__ validates, and validate function make sure ids are recognized, these won't ever be None
-        for cid in catchment_ids:
+        for cid in self.catchment_ids:
             self._catchments.add(hydrofabric.get_catchment_by_id(cid))
-        for nid in nexus_ids:
+        for nid in self.nexus_ids:
             self._nexuses.add(hydrofabric.get_nexus_by_id(nid))
 
     @property

--- a/python/lib/modeldata/dmod/modeldata/subset/hydrofabric_subset.py
+++ b/python/lib/modeldata/dmod/modeldata/subset/hydrofabric_subset.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from hypy import Catchment, Nexus
-from typing import Collection, Optional, Sequence, Set, Tuple, Union
+from typing import Collection, Optional, Set, Tuple
 from ..hydrofabric import Hydrofabric
 from .subset_definition import SubsetDefinition
 
@@ -22,17 +22,19 @@ class HydrofabricSubset(SubsetDefinition, ABC):
     made in the case of invalid objects.  In such cases, the hash is equal to the super class hash output plus ``1``.
     """
 
-    __slots__ = ["_hydrofabric"]
+    hydrofabric: Hydrofabric
 
-    def __init__(self, catchment_ids: Collection[str], nexus_ids: Collection[str], hydrofabric: Hydrofabric):
-        super().__init__(catchment_ids=catchment_ids, nexus_ids=nexus_ids)
+    class Config:
+        arbitrary_types_allowed = True
+
+    def __init__(self, catchment_ids: Collection[str], nexus_ids: Collection[str], hydrofabric: Hydrofabric, **data):
         if not self.validate_hydrofabric(hydrofabric):
             raise RuntimeError("Insufficient or wrongly formatted hydrofabric when trying to create {} object".format(
                 self.__class__.__name__
             ))
-        self._hydrofabric = hydrofabric
+        super().__init__(catchment_ids=catchment_ids, nexus_ids=nexus_ids, hydrofabric=hydrofabric, **data)
 
-    def __eq__(self, other):
+    def __eq__(self, other: object):
         if isinstance(other, self.__class__):
             return self.validate_hydrofabric() == other.validate_hydrofabric() and super().__eq__(other)
         else:

--- a/python/lib/modeldata/dmod/modeldata/subset/hydrofabric_subset.py
+++ b/python/lib/modeldata/dmod/modeldata/subset/hydrofabric_subset.py
@@ -49,7 +49,7 @@ class HydrofabricSubset(SubsetDefinition, ABC):
 
     @property
     @abstractmethod
-    def catchments(self) -> Tuple[Catchment]:
+    def catchments(self) -> Tuple[Catchment, ...]:
         """
         Get the associated catchments as ::class:`Catchment` objects.
 
@@ -62,7 +62,7 @@ class HydrofabricSubset(SubsetDefinition, ABC):
 
     @property
     @abstractmethod
-    def nexuses(self) -> Tuple[Nexus]:
+    def nexuses(self) -> Tuple[Nexus, ...]:
         """
         Get the associated nexuses as ::class:`Nexus` objects.
 
@@ -148,19 +148,19 @@ class SimpleHydrofabricSubset(HydrofabricSubset):
 
         Returns
         -------
-        Tuple[Catchment]
+        Tuple[Catchment, ...]
             The associated catchments as ::class:`Catchment` objects.
         """
         return tuple(self._catchments)
 
     @property
-    def nexuses(self) -> Tuple[Nexus]:
+    def nexuses(self) -> Tuple[Nexus, ...]:
         """
         Get the associated nexuses as ::class:`Nexus` objects.
 
         Returns
         -------
-        Tuple[Catchment]
+        Tuple[Catchment, ...]
             The associated nexuses as ::class:`Nexus` objects.
         """
         return tuple(self._nexuses)

--- a/python/lib/modeldata/dmod/modeldata/subset/hydrofabric_subset.py
+++ b/python/lib/modeldata/dmod/modeldata/subset/hydrofabric_subset.py
@@ -28,11 +28,11 @@ class HydrofabricSubset(SubsetDefinition, ABC):
         arbitrary_types_allowed = True
 
     def __init__(self, catchment_ids: Collection[str], nexus_ids: Collection[str], hydrofabric: Hydrofabric, **data):
+        super().__init__(catchment_ids=catchment_ids, nexus_ids=nexus_ids, hydrofabric=hydrofabric, **data)
         if not self.validate_hydrofabric(hydrofabric):
             raise RuntimeError("Insufficient or wrongly formatted hydrofabric when trying to create {} object".format(
                 self.__class__.__name__
             ))
-        super().__init__(catchment_ids=catchment_ids, nexus_ids=nexus_ids, hydrofabric=hydrofabric, **data)
 
     def __eq__(self, other: object):
         if isinstance(other, self.__class__):

--- a/python/lib/modeldata/dmod/modeldata/subset/subset_definition.py
+++ b/python/lib/modeldata/dmod/modeldata/subset/subset_definition.py
@@ -13,11 +13,11 @@ class SubsetDefinition(Serializable):
     to be immutable.
     """
 
-    catchment_ids: Tuple[str]
-    nexus_ids: Tuple[str]
+    catchment_ids: Tuple[str, ...]
+    nexus_ids: Tuple[str, ...]
 
     @validator("catchment_ids", "nexus_ids")
-    def _sort_and_dedupe_fields(cls, value: Tuple[str]) -> Tuple[str]:
+    def _sort_and_dedupe_fields(cls, value: Tuple[str, ...]) -> Tuple[str, ...]:
         return tuple(sorted(set(value)))
 
     def __init__(self, catchment_ids: Collection[str], nexus_ids: Collection[str], **data):

--- a/python/lib/modeldata/dmod/modeldata/subset/subset_definition.py
+++ b/python/lib/modeldata/dmod/modeldata/subset/subset_definition.py
@@ -20,8 +20,8 @@ class SubsetDefinition(Serializable):
     def _sort_and_dedupe_fields(cls, value: Tuple[str]) -> Tuple[str]:
         return tuple(sorted(set(value)))
 
-    def __init__(self, catchment_ids: Collection[str], nexus_ids: Collection[str]):
-        super().__init__(catchment_ids=catchment_ids, nexus_ids=nexus_ids)
+    def __init__(self, catchment_ids: Collection[str], nexus_ids: Collection[str], **data):
+        super().__init__(catchment_ids=catchment_ids, nexus_ids=nexus_ids, **data)
 
     def __eq__(self, other: object):
         return (

--- a/python/lib/modeldata/dmod/test/it_object_store_dataset_manager.py
+++ b/python/lib/modeldata/dmod/test/it_object_store_dataset_manager.py
@@ -253,7 +253,7 @@ class IntegrationTestObjectStoreDatasetManager(unittest.TestCase):
 
         data_dict = json.loads(self.manager.get_data(dataset_name, item_name=serial_file_name).decode())
 
-        self.assertEqual(dataset_name, data_dict[Dataset._KEY_NAME])
+        self.assertEqual(dataset_name, data_dict["name"])
 
     def test_list_files_1_a(self):
         """

--- a/python/lib/modeldata/dmod/test/test_partition.py
+++ b/python/lib/modeldata/dmod/test/test_partition.py
@@ -1,0 +1,95 @@
+import unittest
+from ..modeldata.hydrofabric.partition import Partition, PartitionConfig
+
+class TestPartition(unittest.TestCase):
+
+    @classmethod
+    @property
+    def partition_instance(cls) -> Partition:
+        return Partition(
+                nexus_ids=["2"],
+                catchment_ids=["42"],
+                partition_id=0,
+                remote_up_nexuses=["1"],
+                remote_down_nexuses=["3"]
+                )
+
+    @classmethod
+    @property
+    def serialized_partition(cls) -> dict:
+        return {
+                "cat-ids": ["42"],
+                "id": 0,
+                "remote-up": ["1"],
+                "nex-ids": ["2"],
+                "remote-down": ["3"]
+                }
+
+
+    def test_programmatically_create_partition(self):
+        """Test creating an instance programmatically"""
+        o = self.partition_instance
+
+        self.assertEqual(len(o.catchment_ids), 1)
+        self.assertEqual(len(o.remote_upstream_nexus_ids), 1)
+        self.assertEqual(len(o.nexus_ids), 1)
+        self.assertEqual(len(o.remote_downstream_nexus_ids), 1)
+
+        self.assertIn
+        self.assertEqual(o.partition_id, 0)
+        self.assertIn("42", o.catchment_ids)
+        self.assertIn("1", o.remote_upstream_nexus_ids)
+        self.assertIn("2", o.nexus_ids)
+        self.assertIn("3", o.remote_downstream_nexus_ids)
+
+    def test_factory_init_from_deserialized_json(self):
+        """
+        Test creating an instance from a dictionary, then re-serializing equals the original dict.
+        """
+        data = self.serialized_partition
+        o = Partition.factory_init_from_deserialized_json(data)
+        self.assertIsNotNone(o)
+        self.assertDictEqual(data, o.to_dict()) # type: ignore
+
+    def test_eq(self):
+        """
+        Test equality of instances. Tests instances created programmatically and from dict
+        deserialization.
+        """
+        o1 = self.partition_instance
+        o2 = self.partition_instance
+
+        o3 = Partition.factory_init_from_deserialized_json(self.serialized_partition)
+        self.assertEqual(o1, o1)
+        self.assertEqual(o1, o2)
+        self.assertEqual(o1, o3)
+
+    def test_hash(self):
+        """
+        Test instances hash to the same value based on their data, not the order of their data.
+        """
+        catchment_ids = ["1", "2", "3"]
+        rev_catchment_ids = catchment_ids[::-1]
+
+        o1 = Partition(
+                # these fields are used by __hash__
+                catchment_ids=catchment_ids,
+                partition_id=0,
+
+                nexus_ids=["2"],
+                remote_up_nexuses=["1"],
+                remote_down_nexuses=["3"]
+                )
+
+        o2 = Partition(
+                # these fields are used by __hash__
+                catchment_ids=rev_catchment_ids,
+                partition_id=0,
+
+                nexus_ids=["2"],
+                remote_up_nexuses=["1"],
+                remote_down_nexuses=["3"]
+                )
+
+        self.assertNotEqual(catchment_ids, rev_catchment_ids)
+        self.assertEqual(hash(o1), hash(o2))

--- a/python/lib/modeldata/dmod/test/test_partition.py
+++ b/python/lib/modeldata/dmod/test/test_partition.py
@@ -1,30 +1,29 @@
 import unittest
 from ..modeldata.hydrofabric.partition import Partition, PartitionConfig
 
-class TestPartition(unittest.TestCase):
 
+class TestPartition(unittest.TestCase):
     @classmethod
     @property
     def partition_instance(cls) -> Partition:
         return Partition(
-                nexus_ids=["2"],
-                catchment_ids=["42"],
-                partition_id=0,
-                remote_up_nexuses=["1"],
-                remote_down_nexuses=["3"]
-                )
+            nexus_ids=["2"],
+            catchment_ids=["42"],
+            partition_id=0,
+            remote_up_nexuses=["1"],
+            remote_down_nexuses=["3"],
+        )
 
     @classmethod
     @property
     def serialized_partition(cls) -> dict:
         return {
-                "cat-ids": ["42"],
-                "id": 0,
-                "remote-up": ["1"],
-                "nex-ids": ["2"],
-                "remote-down": ["3"]
-                }
-
+            "cat-ids": ["42"],
+            "id": 0,
+            "remote-up": ["1"],
+            "nex-ids": ["2"],
+            "remote-down": ["3"],
+        }
 
     def test_programmatically_create_partition(self):
         """Test creating an instance programmatically"""
@@ -49,7 +48,7 @@ class TestPartition(unittest.TestCase):
         data = self.serialized_partition
         o = Partition.factory_init_from_deserialized_json(data)
         self.assertIsNotNone(o)
-        self.assertDictEqual(data, o.to_dict()) # type: ignore
+        self.assertDictEqual(data, o.to_dict())  # type: ignore
 
     def test_eq(self):
         """
@@ -72,24 +71,155 @@ class TestPartition(unittest.TestCase):
         rev_catchment_ids = catchment_ids[::-1]
 
         o1 = Partition(
-                # these fields are used by __hash__
-                catchment_ids=catchment_ids,
-                partition_id=0,
-
-                nexus_ids=["2"],
-                remote_up_nexuses=["1"],
-                remote_down_nexuses=["3"]
-                )
+            # these fields are used by __hash__
+            catchment_ids=catchment_ids,
+            partition_id=0,
+            nexus_ids=["2"],
+            remote_up_nexuses=["1"],
+            remote_down_nexuses=["3"],
+        )
 
         o2 = Partition(
-                # these fields are used by __hash__
-                catchment_ids=rev_catchment_ids,
-                partition_id=0,
-
-                nexus_ids=["2"],
-                remote_up_nexuses=["1"],
-                remote_down_nexuses=["3"]
-                )
+            # these fields are used by __hash__
+            catchment_ids=rev_catchment_ids,
+            partition_id=0,
+            nexus_ids=["2"],
+            remote_up_nexuses=["1"],
+            remote_down_nexuses=["3"],
+        )
 
         self.assertNotEqual(catchment_ids, rev_catchment_ids)
         self.assertEqual(hash(o1), hash(o2))
+
+    def test_to_dict(self):
+        """Test serializing to dict"""
+        o = Partition.factory_init_from_deserialized_json(self.serialized_partition)
+
+        self.assertIsNotNone(o)
+        self.assertDictEqual(o.to_dict(), self.serialized_partition)  # type: ignore
+
+
+class TestPartitionConfig(unittest.TestCase):
+    @classmethod
+    @property
+    def partition_config_instance(cls) -> PartitionConfig:
+        return PartitionConfig(partitions=[TestPartition.partition_instance])
+
+    @classmethod
+    @property
+    def serialized_partition_config(cls) -> dict:
+        return {"partitions": [TestPartition.serialized_partition]}
+
+    def test_programmatically_create_partition(self):
+        """Test creating an instance programmatically"""
+        o = self.partition_config_instance
+
+        self.assertEqual(len(o.partitions), 1)
+
+    def test_factory_init_from_deserialized_json(self):
+        """Test creating an instance programmatically"""
+        data = self.serialized_partition_config
+        o = PartitionConfig.factory_init_from_deserialized_json(data)
+
+        self.assertIsNotNone(o)
+        self.assertDictEqual(data, o.to_dict())  # type: ignore
+
+    def test_to_dict(self):
+        o = PartitionConfig.factory_init_from_deserialized_json(
+            self.serialized_partition_config
+        )
+        self.assertIsNotNone(o)
+        self.assertDictEqual(self.serialized_partition_config, o.to_dict())  # type: ignore
+
+    def test_hash(self):
+        """
+        Test instances hash to the same value based on their data, not the order of their data.
+        """
+        self.assertEqual(
+            hash(self.partition_config_instance), hash(self.partition_config_instance)
+        )
+
+        # from dictionary
+        o = PartitionConfig.factory_init_from_deserialized_json(
+            self.partition_config_instance.to_dict()
+        )
+        self.assertEqual(hash(self.partition_config_instance), hash(o))
+
+        catchment_ids = ["1", "2", "3"]
+
+        o1 = PartitionConfig(
+            partitions=[
+                Partition(
+                    nexus_ids=["1"],
+                    remote_up_nexuses=["2"],
+                    remote_down_nexuses=["3"],
+                    partition_id=0,
+                    catchment_ids=catchment_ids,
+                )
+            ]
+        )
+
+        o2 = PartitionConfig(
+            partitions=[
+                Partition(
+                    nexus_ids=["2222"],
+                    remote_up_nexuses=["1111"],
+                    remote_down_nexuses=["3333"],
+                    partition_id=0,
+                    catchment_ids=catchment_ids,
+                )
+            ]
+        )
+
+        # same partition and catchment ids
+        # NOTE: this is the expected behavior
+        self.assertEqual(hash(o1), hash(o2))
+
+    def test_duplicate_partitions_removed_during_init(self):
+        catchment_ids = ["1", "2", "3"]
+        rev_catchment_ids = catchment_ids[::-1]
+
+        o1 = Partition(
+            nexus_ids=["2"],
+            remote_up_nexuses=["1"],
+            remote_down_nexuses=["3"],
+            partition_id=0,
+            catchment_ids=catchment_ids,
+        )
+
+        o2 = Partition(
+            nexus_ids=["2"],
+            remote_up_nexuses=["1"],
+            remote_down_nexuses=["3"],
+            partition_id=0,
+            catchment_ids=rev_catchment_ids,
+        )
+
+        duplicate_partition_inst = PartitionConfig(partitions=[o1, o1])
+        self.assertEqual(len(duplicate_partition_inst.partitions), 1)
+
+        duplicate_partition_same_data_inst = PartitionConfig(partitions=[o1, o2])
+        self.assertEqual(len(duplicate_partition_same_data_inst.partitions), 1)
+        catchment_ids = ["1", "2", "3"]
+
+        o1 = Partition(
+            nexus_ids=["2"],
+            remote_up_nexuses=["1"],
+            remote_down_nexuses=["3"],
+            partition_id=0,
+            catchment_ids=catchment_ids,
+        )
+
+        o3 = Partition(
+            nexus_ids=["2222"],
+            remote_up_nexuses=["1111"],
+            remote_down_nexuses=["3333"],
+            partition_id=0,
+            catchment_ids=catchment_ids,
+        )
+
+        same_catchment_id_and_partition_id = PartitionConfig(partitions=[o1, o3])
+
+        # NOTE: this is the expected behavior
+        self.assertEqual(len(same_catchment_id_and_partition_id.partitions), 1)
+

--- a/python/lib/modeldata/dmod/test/test_partition.py
+++ b/python/lib/modeldata/dmod/test/test_partition.py
@@ -3,10 +3,7 @@ from ..modeldata.hydrofabric.partition import Partition, PartitionConfig
 
 
 class TestPartition(unittest.TestCase):
-    @classmethod
-    @property
-    def partition_instance(cls) -> Partition:
-        return Partition(
+    partition_instance = Partition(
             nexus_ids=["2"],
             catchment_ids=["42"],
             partition_id=0,
@@ -14,10 +11,7 @@ class TestPartition(unittest.TestCase):
             remote_down_nexuses=["3"],
         )
 
-    @classmethod
-    @property
-    def serialized_partition(cls) -> dict:
-        return {
+    serialized_partition = {
             "cat-ids": ["42"],
             "id": 0,
             "remote-up": ["1"],
@@ -100,15 +94,9 @@ class TestPartition(unittest.TestCase):
 
 
 class TestPartitionConfig(unittest.TestCase):
-    @classmethod
-    @property
-    def partition_config_instance(cls) -> PartitionConfig:
-        return PartitionConfig(partitions=[TestPartition.partition_instance])
+    partition_config_instance = PartitionConfig(partitions=[TestPartition.partition_instance])
 
-    @classmethod
-    @property
-    def serialized_partition_config(cls) -> dict:
-        return {"partitions": [TestPartition.serialized_partition]}
+    serialized_partition_config = {"partitions": [TestPartition.serialized_partition]}
 
     def test_programmatically_create_partition(self):
         """Test creating an instance programmatically"""

--- a/python/lib/modeldata/setup.py
+++ b/python/lib/modeldata/setup.py
@@ -30,6 +30,7 @@ setup(
         "aiohttp<=3.7.4",
         "hypy@git+https://github.com/NOAA-OWP/hypy@master#egg=hypy&subdirectory=python",
         "gitpython",
+        "pydantic",
     ],
     packages=find_namespace_packages(exclude=["dmod.test", "schemas", "ssl", "src"]),
 )

--- a/python/lib/modeldata/setup.py
+++ b/python/lib/modeldata/setup.py
@@ -4,23 +4,31 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent
 
 try:
-    with open(ROOT / 'README.md', 'r') as readme:
+    with open(ROOT / "README.md", "r") as readme:
         long_description = readme.read()
 except:
-    long_description = ''
+    long_description = ""
 
-exec(open(ROOT / 'dmod/modeldata/_version.py').read())
+exec(open(ROOT / "dmod/modeldata/_version.py").read())
 
 setup(
-    name='dmod-modeldata',
+    name="dmod-modeldata",
     version=__version__,
-    description='',
+    description="",
     long_description=long_description,
-    author='',
-    author_email='',
-    url='',
-    license='',
-    install_requires=['numpy>=1.20.1', 'pandas', 'geopandas', 'dmod-communication>=0.4.2', 'dmod-core>=0.3.0', 'minio',
-                      'aiohttp<=3.7.4', 'hypy@git+https://github.com/NOAA-OWP/hypy@master#egg=hypy&subdirectory=python'],
-    packages=find_namespace_packages(exclude=['dmod.test', 'schemas', 'ssl', 'src'])
+    author="",
+    author_email="",
+    url="",
+    license="",
+    install_requires=[
+        "numpy>=1.20.1",
+        "pandas",
+        "geopandas",
+        "dmod-communication>=0.4.2",
+        "dmod-core>=0.3.0",
+        "minio",
+        "aiohttp<=3.7.4",
+        "hypy@git+https://github.com/NOAA-OWP/hypy@master#egg=hypy&subdirectory=python",
+    ],
+    packages=find_namespace_packages(exclude=["dmod.test", "schemas", "ssl", "src"]),
 )

--- a/python/lib/modeldata/setup.py
+++ b/python/lib/modeldata/setup.py
@@ -29,6 +29,7 @@ setup(
         "minio",
         "aiohttp<=3.7.4",
         "hypy@git+https://github.com/NOAA-OWP/hypy@master#egg=hypy&subdirectory=python",
+        "gitpython",
     ],
     packages=find_namespace_packages(exclude=["dmod.test", "schemas", "ssl", "src"]),
 )


### PR DESCRIPTION
This PR refactors `dmod.modeldata`'s `dmod.core.serializable.Serializable` subtypes into compliance with the changes introduced in #239. These changes should _not_ affect downstream usage of `dmod.modeldata` `Serializable` subtypes.

For broader context, implications, and examples regarding changes that affect the `Serializable` subtype, see #239. 


## Changes

- Serialization, deserialization, validation, and type coercion are now mainly handled by [pydantic](https://docs.pydantic.dev/usage/models/#basic-model-usage). All subtypes of dmod.core.serializable.Serializable are affected by this change.
- `pydantic` added as `dmod.modeldata` dependency
- missing dependency, `GitPython`, added to `dmod.modeldata`'s `setup.py`


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: