### PR TITLE
Refactor dmod.scheduler serialization and deserialization types 

### DIFF
--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -6,8 +6,8 @@ from dmod.core.execution import AllocationParadigm
 from dmod.communication import ExternalRequest, ModelExecRequest, NGENRequest, SchedulerRequestMessage
 from dmod.core.serializable import Serializable
 from dmod.core.meta_data import DataRequirement
+from dmod.core.enum import PydanticEnum
 from dmod.modeldata.hydrofabric import PartitionConfig
-from enum import Enum
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 from uuid import UUID
 from uuid import uuid4 as uuid_func
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 import logging
 
 
-class JobExecStep(Enum):
+class JobExecStep(PydanticEnum):
     """
     A component of a JobStatus, representing the particular step within a "phase" encoded within the current status.
 
@@ -133,7 +133,7 @@ class JobExecStep(Enum):
         return self._uid
 
 
-class JobExecPhase(Enum):
+class JobExecPhase(PydanticEnum):
     """
     A component of a JobStatus, representing the high level transition stage at which a status exists.
     """

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -328,11 +328,11 @@ class JobStatus(Serializable):
 
     @property
     def job_exec_phase(self) -> JobExecPhase:
-        return self.phase
+        return self.phase # type: ignore
 
     @property
     def job_exec_step(self) -> JobExecStep:
-        return self.step
+        return self.step # type: ignore
 
     @property
     def name(self) -> str:

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -336,8 +336,7 @@ class JobStatus(Serializable):
 
     @property
     def name(self) -> str:
-        return self.job_exec_phase.name + self._NAME_DELIMITER + self.job_exec_step.name
-
+        return f"{self.job_exec_phase.name}{self._NAME_DELIMITER}{self.job_exec_step.name}"
 
 class Job(Serializable, ABC):
     """

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -11,16 +11,18 @@ from dmod.core.serializable import Serializable
 from dmod.core.meta_data import DataRequirement
 from dmod.core.enum import PydanticEnum
 from dmod.modeldata.hydrofabric import PartitionConfig
-from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Set, Tuple, Type, TYPE_CHECKING, Union
+from typing_extensions import Self
 from uuid import UUID
 from uuid import uuid4 as uuid_func
 
 from ..resources import ResourceAllocation
-
-if TYPE_CHECKING:
-    from .. import RsaKeyPair
+from .. import RsaKeyPair
 
 import logging
+
+if TYPE_CHECKING:
+    from pydantic.typing import AbstractSetIntStr, MappingIntStrAny, DictStrAny
 
 # SAFETY: tuple can be used in this context because this sentinel is being used to verify if the data is being
 # deserialized from json. Tuple's are not datatypes in json or deserialized json.
@@ -648,158 +650,87 @@ class Job(Serializable, ABC):
 
         setter_fn(value)
 
-        if key not in json_obj:
-            return None
+class JobImpl(Job):
+    """
+    Basic implementation of ::class:`Job`
 
-        serial_list = json_obj[key]
-        if not isinstance(serial_list, list):
-            raise RuntimeError("Invalid format for data requirements list value '{}'".format(str(serial_list)))
-        data_req_list = []
-        for serial_data_req in serial_list:
-            if not isinstance(serial_data_req, dict):
-                raise RuntimeError("Invalid format for data requirements value '{}'".format(str(serial_list)))
-            data_req = DataRequirement.factory_init_from_deserialized_json(serial_data_req)
-            if not isinstance(data_req, DataRequirement):
-                msg = "Unable to deserialize `{}` to nested data requirements while deserializing {}"
-                raise RuntimeError(msg.format(serial_data_req, cls.__name__))
-            data_req_list.append(data_req)
-        return data_req_list
+    Job ids are simply the string cast of generated UUID values, stored within the ::attribute:`job_uuid` property.
+    """
 
-    @classmethod
-    def _parse_serialized_job_status(cls, json_obj: dict, key: Optional[str] = None):
-        # Set this to the default value if it is initially None
-        if key is None:
-            key = 'status'
-        status_str = cls.parse_simple_serialized(json_obj=json_obj, key=key, expected_type=str, required_present=False)
-        if status_str is None:
-            return None
-        return JobStatus.get_for_name(name=status_str)
+    # NOTE: more specific ExternalRequest subtype than super class
+    model_request: ModelExecRequest
 
-    @classmethod
-    def _parse_serialized_last_updated(cls, json_obj: dict, key: Optional[str] = None):
-        date_str_converter = lambda date_str: datetime.strptime(date_str, cls.get_datetime_str_format())
-        if key is None:
-            key = 'last_updated'
-        if key in json_obj:
-            return cls.parse_simple_serialized(json_obj=json_obj, key=key, expected_type=datetime,
-                                               converter=date_str_converter, required_present=False)
-        else:
-            return None
+    _worker_data_requirements: Optional[List[List[DataRequirement]]] = PrivateAttr(None)
+    _allocation_service_names: Optional[Tuple[str]] = PrivateAttr(None)
 
-    @classmethod
-    def _parse_serialized_partition_config(cls, json_obj: dict, key: Optional[str] = None):
-        if key is None:
-            key = 'partitioning'
-        if key in json_obj:
-            return PartitionConfig.factory_init_from_deserialized_json(json_obj[key])
-        else:
-            return None
+    @validator("allocation_paradigm", pre=True)
+    def _parse_allocation_paradigm(cls, value: Union[AllocationParadigm, str]) -> Union[str, AllocationParadigm]:
+        if isinstance(value, AllocationParadigm):
+            return value
 
-    @classmethod
-    def _parse_serialized_rsa_key_pair(cls, json_obj: dict, key: Optional[str] = None, warn_if_missing: bool = False):
-        # Doing this here for now to avoid import errors
-        # TODO: find a better way for this
-        from .. import RsaKeyPair
+        # NOTE: potentially remove in future. There are cases in codebase where kabob case is being used.
+        return value.replace("-", "_")
 
-        # Set this to the default value if it is initially None
-        if key is None:
-            # TODO: set somewhere globally
-            key = 'rsa_key_pair'
-        if key not in json_obj:
-            if warn_if_missing:
-                # TODO: log this better.  NJF changed print to logging.warning, anything else needed?
-                msg = 'Warning: expected serialized RSA key at {} when deserializing {} object'
-                logging.warning(msg.format(key, cls.__name__))
-            return None
-        if key not in json_obj or json_obj[key] is None:
-            return None
-        rsa_key_pair = RsaKeyPair.factory_init_from_deserialized_json(json_obj=json_obj[key])
-        if rsa_key_pair is None:
-            raise RuntimeError('Could not deserialized child RsaKeyPair when deserializing ' + cls.__name__)
-        else:
-            return rsa_key_pair
+    @validator("status", pre=True)
+    def _parse_status(cls, value: Optional[Union[str, JobStatus]], field: ModelField) -> JobStatus:
+        if value is None:
+            if field.default_factory is None:
+                raise RuntimeError("unreachable")
+            return field.default_factory()
+
+        if isinstance(value, JobStatus):
+            return value
+
+        value = str(value)
+        return JobStatus.get_for_name(name=value)
+
+    @validator("last_updated", pre=True)
+    def _parse_serialized_last_updated(cls, value: Union[str, datetime]) -> datetime:
+        if isinstance(value, datetime):
+            return value
+
+        try:
+            value = str(value)
+            return datetime.strptime(value, cls.get_datetime_str_format())
+        except:
+            return datetime.now()
+
+    @validator("data_requirements", pre=True)
+    def _populate_default_data_requirements(cls, value: Optional[List[DataRequirement]]) -> List[DataRequirement]:
+        if value is None:
+            return list()
+        return value
+
+    @validator("model_request", pre=True)
+    def _deserialize_model_request(cls, value: Union[Dict[str, Any], ModelExecRequest]) -> ModelExecRequest:
+        if isinstance(value, ModelExecRequest):
+            return value
+
+        return ModelExecRequest.factory_init_correct_subtype_from_deserialized_json(value)
+
+    @validator("job_id", pre=True)
+    def _validate_job_id(cls, value: Optional[Union[UUID, str]], field: ModelField) -> str:
+        if value is None:
+            if field.default_factory is None:
+                raise RuntimeError("unreachable")
+            return field.default_factory()
+
+        if isinstance(value, UUID):
+            return str(value)
+
+        return str(UUID(value))
+
+    @root_validator(pre=True)
+    def _parse_job_id(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        job_id = values.get("job_id")
+        if job_id is not None:
+            return values
+
+        values["job_id"] = cls.parse_serialized_job_id(job_id, **values)
+        return values
 
     # TODO: unit test
     # TODO: consider moving this up to Job or even Serializable
-
-    @classmethod
-    def deserialize_core_attributes(cls, json_obj: dict):
-        """
-        Deserialize the core attributes of the basic ::class:`JobImpl` implementation from the provided dictionary and
-        return as a tuple.
-
-        Parameters
-        ----------
-        json_obj
-
-        Returns
-        -------
-        The tuple with parse values of (cpus, memory, paradigm, priority, job_id, rsa_key_pair, status, allocations,
-        updated, partitioning) from the provided dictionary.
-        """
-        int_converter = lambda x: int(x)
-        cpus = cls.parse_simple_serialized(json_obj=json_obj, key='cpu_count', expected_type=int,
-                                           converter=int_converter)
-        memory = cls.parse_simple_serialized(json_obj=json_obj, key='memory_size', expected_type=int,
-                                             converter=int_converter)
-        paradigm = cls._parse_serialized_allocation_paradigm(json_obj=json_obj, key='allocation_paradigm')
-        priority = cls.parse_simple_serialized(json_obj=json_obj, key='allocation_priority', expected_type=int,
-                                               converter=int_converter)
-        job_id = cls.parse_serialized_job_id(serialized_value=None, json_obj=json_obj, key='job_id')
-        rsa_key_pair = cls._parse_serialized_rsa_key_pair(json_obj=json_obj)
-        status = cls._parse_serialized_job_status(json_obj=json_obj)
-        allocations = cls._parse_serialized_allocations(json_obj=json_obj)
-        updated = cls._parse_serialized_last_updated(json_obj=json_obj)
-        partitioning = cls._parse_serialized_partition_config(json_obj=json_obj, key='partitioning')
-        return cpus, memory, paradigm, priority, job_id, rsa_key_pair, status, allocations, updated, partitioning
-
-    @classmethod
-    def factory_init_from_deserialized_json(cls, json_obj: dict):
-        """
-        Factory create a new instance of this type based on a JSON object dictionary deserialized from received JSON.
-
-        Parameters
-        ----------
-        json_obj
-
-        Returns
-        -------
-        A new object of this type instantiated from the deserialize JSON object dictionary
-        """
-
-        try:
-            cpus, memory, paradigm, priority, job_id, rsa_key_pair, status, allocations, updated, partitioning = \
-                cls.deserialize_core_attributes(json_obj)
-
-            if 'model_request' in json_obj:
-                model_request = ModelExecRequest.factory_init_correct_subtype_from_deserialized_json(json_obj['model_request'])
-            else:
-                # TODO: add serialize/deserialize support for other situations/requests (also change 'model_request' property name)
-                msg = "Type {} can only support deserializing JSON containing a {} under the 'model_request' key"
-                raise RuntimeError(msg.format(cls.__name__, ModelExecRequest.__name__))
-
-            obj = cls(cpu_count=cpus, memory_size=memory, model_request=model_request, allocation_paradigm=paradigm,
-                      alloc_priority=priority)
-
-            if job_id is not None:
-                obj.job_id = job_id
-            if rsa_key_pair is not None:
-                obj.rsa_key_pair = rsa_key_pair
-            if status is not None:
-                obj.status = status
-            if updated is not None:
-                obj._last_updated = updated
-            if allocations is not None:
-                obj.allocations = allocations
-                obj.data_requirements = cls._parse_serialized_data_requirements(json_obj)
-            if partitioning is not None:
-                obj.partition_config = partitioning
-
-            return obj
-
-        except RuntimeError as e:
-            logging.error(e)
-            return None
 
     @classmethod
     def parse_serialized_job_id(cls, serialized_value: Optional[str], **kwargs):
@@ -850,46 +781,38 @@ class Job(Serializable, ABC):
         RuntimeError
             Raised if the parameter does not parse to a UUID.
         """
+        if serialized_value is not None:
+            return serialized_value
+
         key_key = 'key'
-        json_obj_key = 'json_obj'
 
         # First, try to obtain a serialized value, if one was not already set
-        if serialized_value is None and kwargs is not None and json_obj_key in kwargs and key_key in kwargs:
-            if isinstance(kwargs[json_obj_key], dict) and kwargs[key_key] in kwargs[json_obj_key]:
-                try:
-                    serialized_value = cls.parse_simple_serialized(json_obj=kwargs[json_obj_key], key=kwargs[key_key],
-                                                                   expected_type=str, converter=lambda x: str(x),
-                                                                   required_present=False)
-                except:
-                    # TODO: consider logging this
-                    return None
-        # Bail here if we don't have a serialized_value to work with
-        if serialized_value is None:
-            return None
-        try:
-            return UUID(str(serialized_value))
-        except ValueError as e:
-            msg = "Failed parsing parameter value `{}` to UUID object: {}".format(str(serialized_value), str(e))
-            raise RuntimeError(msg)
+        if kwargs is not None and key_key in kwargs:
+            if kwargs[key_key] in kwargs:
+                return kwargs[kwargs[key_key]]
+
+        return None
+
 
     def __init__(self, cpu_count: int, memory_size: int, model_request: ExternalRequest,
-                 allocation_paradigm: Union[str, AllocationParadigm], alloc_priority: int = 0):
-        self._cpu_count = cpu_count
-        self._memory_size = memory_size
-        self._model_request = model_request
-        if isinstance(allocation_paradigm, AllocationParadigm):
-            self._allocation_paradigm = allocation_paradigm
-        else:
-            self._allocation_paradigm = AllocationParadigm.get_from_name(name=allocation_paradigm)
-        self._allocation_priority = alloc_priority
-        self._job_uuid = uuid_func()
-        self._rsa_key_pair = None
-        self._status = JobStatus(JobExecPhase.INIT)
-        self._allocations = None
-        self._data_requirements = None
-        self._worker_data_requirements = None
-        self._allocation_service_names = None
-        self._partition_config = None
+                 allocation_paradigm: Union[str, AllocationParadigm], alloc_priority: int = 0, **data):
+        if data:
+            super().__init__(
+                allocation_paradigm=allocation_paradigm,
+                cpu_count=cpu_count,
+                memory_size=memory_size,
+                model_request=model_request,
+                **data,
+            )
+            return
+
+        super().__init__(
+            allocation_paradigm=allocation_paradigm,
+            allocation_priority=alloc_priority,
+            cpu_count=cpu_count,
+            memory_size=memory_size,
+            model_request=model_request,
+        )
         self._reset_last_updated()
 
     def _process_per_worker_data_requirements(self) -> List[List[DataRequirement]]:
@@ -901,11 +824,13 @@ class Job(Serializable, ABC):
         List[List[DataRequirement]]
             List (indexed analogously to worker allocations) of lists of per-worker data requirements.
         """
+        if self.allocations is None:
+            return []
         # TODO: implement this properly/more efficiently
-        return [list(self.data_requirements) for a in self.allocations]
+        return [list(self.data_requirements) for _ in self.allocations]
 
     def _reset_last_updated(self):
-        self._last_updated = datetime.now()
+        self.last_updated = datetime.now()
 
     def add_allocation(self, allocation: ResourceAllocation):
         """
@@ -917,44 +842,16 @@ class Job(Serializable, ABC):
         allocation : ResourceAllocation
             A resource allocation object to add.
         """
-        if self._allocations is None:
-            self._allocations = list()
-        self._allocations.append(allocation)
+        if self.allocations is None:
+            self.set_allocations(list())
+        self.allocations.append(allocation) # type: ignore
         self._allocation_service_names = None
         self._reset_last_updated()
 
-    @property
-    def allocation_paradigm(self) -> AllocationParadigm:
-        """
-        The ::class:`AllocationParadigm` type value that was used or should be used to make allocations.
-
-        For this type, the value is set as a private attribute during initialization, based on the value of the
-        ::attribute:`SchedulerRequestMessage.allocation_paradigm` string property present within the provided
-        ::class:`SchedulerRequestMessage` init param.
-
-        Returns
-        -------
-        AllocationParadigm
-            The ::class:`AllocationParadigm` type value that was used or should be used to make allocations.
-        """
-        return self._allocation_paradigm
-
-    @property
-    def allocation_priority(self) -> int:
-        """
-        A score for how this job should be prioritized with respect to allocation, with high scores being more likely to
-        received allocation.
-
-        Returns
-        -------
-        int
-            A score for how this job should be prioritized with respect to allocation.
-        """
-        return self._allocation_priority
-
-    @allocation_priority.setter
-    def allocation_priority(self, priority: int):
-        self._allocation_priority = priority
+    def set_allocation_priority(self, priority: int):
+        # NOTE: set using dict to avoid deprecation warning thrown by `__setattr__`.  See `Job.__setattr__`
+        # docstring for more detail.
+        self.__dict__["allocation_priority"] = priority
         self._reset_last_updated()
 
     @property
@@ -977,7 +874,7 @@ class Job(Serializable, ABC):
             allocations.
         """
         if self._allocation_service_names is None and self.allocations is not None and len(self.allocations) > 0:
-            service_names = []
+            service_names: List[str] = []
             # TODO: read this from request metadata
             base_name = "{}-worker".format(self.model_request.get_model_name())
             num_allocations = len(self.allocations)
@@ -986,42 +883,24 @@ class Job(Serializable, ABC):
             self._allocation_service_names = tuple(service_names)
         return self._allocation_service_names
 
-    @property
-    def allocations(self) -> Optional[Tuple[ResourceAllocation]]:
-        return None if self._allocations is None else tuple(self._allocations)
-
-    @allocations.setter
-    def allocations(self, allocations: Union[List[ResourceAllocation], Tuple[ResourceAllocation]]):
+    def set_allocations(self, allocations: Union[List[ResourceAllocation], Tuple[ResourceAllocation]]):
         if isinstance(allocations, tuple):
-            self._allocations = list(allocations)
+            # NOTE: set using dict to avoid deprecation warning thrown by `__setattr__`.  See `Job.__setattr__`
+            # docstring for more detail.
+            self.__dict__["allocations"] = list(allocations)
         else:
-            self._allocations = allocations
+            # NOTE: set using dict to avoid deprecation warning thrown by `__setattr__`.  See `Job.__setattr__`
+            # docstring for more detail.
+            self.__dict__["allocations"] = allocations
         self._allocation_service_names = None
         self._reset_last_updated()
 
-    @property
-    def cpu_count(self) -> int:
-        return self._cpu_count
-
-    @property
-    def data_requirements(self) -> List[DataRequirement]:
-        """
-        List of ::class:`DataRequirement` objects representing all data needed for the job.
-
-        Returns
-        -------
-        List[DataRequirement]
-            List of ::class:`DataRequirement` objects representing all data needed for the job.
-        """
-        if self._data_requirements is None:
-            self._data_requirements = []
-        return self._data_requirements
-
-    @data_requirements.setter
-    def data_requirements(self, data_requirements: List[DataRequirement]):
+    def set_data_requirements(self, data_requirements: List[DataRequirement]):
         # Make sure to reset worker data requirements if this is changed
         self._worker_data_requirements = None
-        self._data_requirements = data_requirements
+        # NOTE: set using dict to avoid deprecation warning thrown by `__setattr__`.  See `Job.__setattr__`
+        # docstring for more detail.
+        self.__dict__["data_requirements"] = data_requirements
         self._reset_last_updated()
 
     @property
@@ -1038,68 +917,25 @@ class Job(Serializable, ABC):
         """
         return self.model_request is not None and isinstance(self.model_request, NGENRequest)
 
-    @property
-    def job_id(self) -> Optional[str]:
-        """
-        The unique job id for this job in the manager, if one has been set for it, or ``None``.
-
-        The getter for the property returns the ::attribute:`UUID.bytes` field of the ::attribute:`job_uuid` property,
-        if it is set, or ``None`` if it is not set.
-
-        The setter for the property will actually set the ::attribute:`job_uuid` attribute, via a call to the setter for
-        the ::attribute:`job_uuid` property.  ::attribute:`job_id`'s setter can accept either a ::class:`UUID` or a
-        string, with the latter case being used to initialize a ::class:`UUID` object.
-
-        Returns
-        -------
-        Optional[str]
-            The unique job id for this job in the manager, if one has been set for it, or ``None``.
-        """
-        return str(self._job_uuid) if isinstance(self._job_uuid, UUID) else None
-
-    @job_id.setter
-    def job_id(self, job_id: Union[str, UUID]):
+    def set_job_id(self, job_id: Union[str, UUID]):
         job_uuid = job_id if isinstance(job_id, UUID) else UUID(str(job_id))
-        if job_uuid != self._job_uuid:
-            self._job_uuid = job_uuid
+        job_uuid = str(job_uuid)
+        if job_uuid != self.job_id:
+            # NOTE: set using dict to avoid deprecation warning thrown by `__setattr__`.  See `Job.__setattr__`
+            # docstring for more detail.
+            self.__dict__["job_id"] = job_uuid
             self._reset_last_updated()
 
-    @property
-    def memory_size(self) -> int:
-        return self._memory_size
+    def set_partition_config(self, part_config: PartitionConfig):
+        # NOTE: set using dict to avoid deprecation warning thrown by `__setattr__`.  See `Job.__setattr__`
+        # docstring for more detail.
+        self.__dict__["partition_config"] = part_config
 
-    @property
-    def last_updated(self) -> datetime:
-        return self._last_updated
-
-    @property
-    def model_request(self) -> ExternalRequest:
-        """
-        Get the underlying configuration for the model execution that is being requested.
-
-        Returns
-        -------
-        ExternalRequest
-            The underlying configuration for the model execution that is being requested.
-        """
-        return self._model_request
-
-    @property
-    def partition_config(self) -> Optional[PartitionConfig]:
-        return self._partition_config
-
-    @partition_config.setter
-    def partition_config(self, part_config: PartitionConfig):
-        self._partition_config = part_config
-
-    @property
-    def rsa_key_pair(self) -> Optional['RsaKeyPair']:
-        return self._rsa_key_pair
-
-    @rsa_key_pair.setter
-    def rsa_key_pair(self, key_pair: 'RsaKeyPair'):
-        if key_pair != self._rsa_key_pair:
-            self._rsa_key_pair = key_pair
+    def set_rsa_key_pair(self, key_pair: 'RsaKeyPair'):
+        if key_pair != self.rsa_key_pair:
+            # NOTE: set using dict to avoid deprecation warning thrown by `__setattr__`.  See `Job.__setattr__`
+            # docstring for more detail.
+            self.__dict__["rsa_key_pair"] = key_pair
             self._reset_last_updated()
 
     @property
@@ -1117,34 +953,21 @@ class Job(Serializable, ABC):
         # TODO: confirm that allocations should be maintained for stopped output jobs while in eval or calibration phase
         return self.status_step == JobExecStep.FAILED or self.status_phase == JobExecPhase.CLOSED
 
-    @property
-    def status(self) -> JobStatus:
-        return self._status
-
-    @status.setter
-    def status(self, new_status: JobStatus):
-        if new_status != self._status:
-            self._status = new_status
+    def set_status(self, status: JobStatus):
+        if status != self.status:
+            # NOTE: set using dict to avoid deprecation warning thrown by `__setattr__`.  See `Job.__setattr__`
+            # docstring for more detail.
+            self.__dict__["status"] = status
             self._reset_last_updated()
 
-    @property
-    def status_phase(self) -> JobExecPhase:
-        return super().status_phase
+    def set_status_phase(self, phase: JobExecPhase):
+        self.set_status(JobStatus(phase=phase, step=phase.default_start_step))
 
-    @status_phase.setter
-    def status_phase(self, phase: JobExecPhase):
-        self.status = JobStatus(phase=phase, step=phase.default_start_step)
+    def set_status_step(self, step: JobExecStep):
+        self.set_status(JobStatus(phase=self.status.job_exec_phase, step=step))
 
     @property
-    def status_step(self) -> JobExecStep:
-        return super().status_step
-
-    @status_step.setter
-    def status_step(self, new_step: JobExecStep):
-        self.status = JobStatus(phase=self.status.job_exec_phase, step=new_step)
-
-    @property
-    def worker_data_requirements(self) -> List[List[DataRequirement]]:
+    def worker_data_requirements(self) -> Optional[List[List[DataRequirement]]]:
         """
         List of lists of per-worker data requirements, indexed analogously to worker allocations.
 
@@ -1157,64 +980,60 @@ class Job(Serializable, ABC):
             self._worker_data_requirements = self._process_per_worker_data_requirements()
         return self._worker_data_requirements
 
-    def to_dict(self) -> dict:
-        """
-        Get the representation of this instance as a dictionary or dictionary-like object (e.g., a JSON object).
+    @cache
+    def _setter_methods(self) -> Dict[str, Callable]:
+        return {
+            **super()._setter_methods(),
+            "allocation_priority": self.set_allocation_priority,
+            "job_id": self.set_job_id,
+            "rsa_key_pair": self.set_rsa_key_pair,
+         }
 
-        {
-            "job_class" : "<class_name>",
-            "cpu_count" : 4,
-            "memory_size" : 1000,
-            "model_request" : {<serialized_maas_request>},
-            "allocation_paradigm" : "SINGLE_NODE",
-            "allocation_priority" : 0,
-            "job_id" : "12345678-1234-5678-1234-567812345678",
-            "rsa_key_pair" : {<serialized_representation_of_RsaKeyPair_obj>},
-            "status" : INIT:DEFAULT,
-            "last_updated" : "2020-07-10 12:05:45",
-            "allocations" : [...],
-            'data_requirements" : [...],
-            "partitioning" : { "partitions": [ ... ] }
-        }
+    def dict(
+        self,
+        *,
+        include: Optional[Union["AbstractSetIntStr", "MappingIntStrAny"]] = None,
+        exclude: Optional[Union["AbstractSetIntStr", "MappingIntStrAny"]] = None,
+        by_alias: bool = True, # Note, this follows Serializable convention
+        skip_defaults: Optional[bool] = None,
+        exclude_unset: bool = False,
+        exclude_defaults: bool = False,
+        exclude_none: bool = True,
+    ) -> "DictStrAny":
+        def add(*fields: str, collection: Union[Set[str], Dict[str, bool]]) -> Union[Set[str], Dict[str, bool]]:
+            if isinstance(collection, set):
+                collection_copy = {*collection}
+                for field in fields:
+                    collection_copy.add(field)
+                return collection_copy
 
-        Returns
-        -------
-        dict
-            the representation of this instance as a dictionary or dictionary-like object (e.g., a JSON object)
-        """
-        serial = dict()
+            elif isinstance(exclude, dict):
+                collection_copy = {**collection}
+                for field in fields:
+                    collection_copy[field] = True
+                return collection_copy
 
-        serial['job_class'] = self.__class__.__name__
-        serial['cpu_count'] = self.cpu_count
-        serial['memory_size'] = self.memory_size
+            return collection
 
-        # TODO: support other scenarios along with deserializing (maybe even eliminate RequestedJob subtype)
-        if isinstance(self.model_request, ModelExecRequest):
-            request_key = 'model_request'
-        else:
-            msg = "Type {} can only support serializing to JSON when fulfilled request is a {}"
-            raise RuntimeError(msg.format(self.__class__.__name__, ModelExecRequest.__name__))
-        serial[request_key] = self.model_request.to_dict()
+        exclude = exclude or set()
 
-        if self.allocation_paradigm:
-            serial['allocation_paradigm'] = self.allocation_paradigm.name
-        serial['allocation_priority'] = self.allocation_priority
-        if self.job_id is not None:
-            serial['job_id'] = str(self.job_id)
-        if self.rsa_key_pair is not None:
-            serial['rsa_key_pair'] = self.rsa_key_pair.to_dict()
-        serial['status'] = self.status.name
-        serial['last_updated'] = self._last_updated.strftime(self.get_datetime_str_format())
-        serial['data_requirements'] = []
-        for dr in self.data_requirements:
-            serial['data_requirements'].append(dr.to_dict())
-        if self.allocations is not None and len(self.allocations) > 0:
-            serial['allocations'] = []
-            for allocation in self.allocations:
-                serial['allocations'].append(allocation.to_dict())
-            if self.partition_config is not None:
-                serial['partitioning'] = self.partition_config.to_dict()
+        # conditionally exclude `allocations` and `partitioning` if allocations is None or is empty
+        if self.allocations is None or not len(self.allocations):
+            exclude = add("allocations", "partitioning", collection=exclude)
 
+        serial = super().dict(
+            include=include,
+            exclude=exclude,
+            by_alias=by_alias,
+            skip_defaults=skip_defaults,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            exclude_none=exclude_none,
+        )
+
+        # serialize status as "{PHASE}:{STEP}"
+        if "status" not in exclude:
+            serial["status"] = self.status.name
         return serial
 
 

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from functools import cache
 from pydantic import Field, PrivateAttr, validator, root_validator
 from pydantic.fields import ModelField
 from warnings import warn
@@ -609,7 +608,6 @@ class Job(Serializable, ABC):
         """
         pass
 
-    @cache
     def _setter_methods(self) -> Dict[str, Callable]:
         """Mapping of attribute name to setter method. This supports backwards functional compatibility."""
         # TODO: remove once migration to setters by down stream users is complete
@@ -980,7 +978,6 @@ class JobImpl(Job):
             self._worker_data_requirements = self._process_per_worker_data_requirements()
         return self._worker_data_requirements
 
-    @cache
     def _setter_methods(self) -> Dict[str, Callable]:
         return {
             **super()._setter_methods(),

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -358,7 +358,7 @@ class Job(Serializable, ABC):
     allocation_priority: int = 0
     """A score for how this job should be prioritized with respect to allocation."""
 
-    allocations: Optional[List[ResourceAllocation]]
+    allocations: Optional[Tuple[ResourceAllocation, ...]]
     """The scheduler resource allocations for this job, or ``None`` if it is queued or otherwise not yet allocated."""
 
     cpu_count: int = Field(gt=0)
@@ -841,8 +841,8 @@ class JobImpl(Job):
             A resource allocation object to add.
         """
         if self.allocations is None:
-            self.set_allocations(list())
-        self.allocations.append(allocation) # type: ignore
+            self.set_allocations(tuple())
+        self.set_allocations((*self.allocations, allocation)) # type: ignore
         self._allocation_service_names = None
         self._reset_last_updated()
 
@@ -882,10 +882,10 @@ class JobImpl(Job):
         return self._allocation_service_names
 
     def set_allocations(self, allocations: Union[List[ResourceAllocation], Tuple[ResourceAllocation]]):
-        if isinstance(allocations, tuple):
+        if isinstance(allocations, list):
             # NOTE: set using dict to avoid deprecation warning thrown by `__setattr__`.  See `Job.__setattr__`
             # docstring for more detail.
-            self.__dict__["allocations"] = list(allocations)
+            self.__dict__["allocations"] = tuple(allocations)
         else:
             # NOTE: set using dict to avoid deprecation warning thrown by `__setattr__`.  See `Job.__setattr__`
             # docstring for more detail.

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -221,7 +221,7 @@ class JobStatus(Serializable):
     """
     Representation of a ::class:`Job`'s status as a combination of phase and exec step.
     """
-    _NAME_DELIMITER = ':'
+    _NAME_DELIMITER: ClassVar[str] = ':'
 
     # NOTE: `None` is valid input, default value for field will be used.
     phase: Optional[JobExecPhase] = Field(JobExecPhase.UNKNOWN)

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -1043,119 +1043,44 @@ class RequestedJob(JobImpl):
     in the form of a ::class:`SchedulerRequestMessage` object.
     """
 
-    @classmethod
-    def factory_init_from_deserialized_json(cls, json_obj: dict):
-        """
-        Factory create a new instance of this type based on a JSON object dictionary deserialized from received JSON.
+    originating_request: SchedulerRequestMessage
+    """The original request that resulted in the creation of this job."""
 
-        Parameters
-        ----------
-        json_obj
+    class Config: # type: ignore
+        fields = {
+            # exclude `model_request` during serialization
+            "model_request": {"exclude": True}
+            }
 
-        Returns
-        -------
-        A new object of this type instantiated from the deserialize JSON object dictionary
-        """
+    def __init__(self, job_request: SchedulerRequestMessage = None, **data):
+        if data:
+            # NOTE: in previous version of code, `model_request` was always a derived field.
+            # this allows `model_request` be separately specified
+            if "model_request" in data:
+                super().__init__(**data)
+                return
 
-        originating_request_key = 'originating_request'
+            originating_request = data.get("originating_request")
+            if originating_request is None:
+                # this should fail, let pydantic handle that.
+                super().__init__(**data)
+                return
 
-        try:
-            cpus, memory, paradigm, priority, job_id, rsa_key_pair, status, allocations, updated, partitioning = \
-                cls.deserialize_core_attributes(json_obj)
+            if isinstance(originating_request, SchedulerRequestMessage):
+                # inject
+                data["model_request"] = originating_request.model_request
 
-            if originating_request_key not in json_obj:
-                msg = 'Key for originating request ({}) not present when deserialize {} object'
-                raise RuntimeError(msg.format(originating_request_key, cls.__name__))
-            request = SchedulerRequestMessage.factory_init_from_deserialized_json(json_obj[originating_request_key])
-            if request is None:
-                msg = 'Invalid serialized scheduler request when deserialize {} object'
-                raise RuntimeError(msg.format(cls.__name__))
-        except Exception as e:
-            logging.error(e)
-            return None
+            data["model_request"] = originating_request.get("model_request")
+            super().__init__(**data)
+            return
 
-        # Create the object initially from the request
-        new_obj = cls(job_request=request)
-
-        # Then update its properties based on the deserialized values, as those are considered most correct
-
-        # Use property setter for job id to handle string or UUID
-        new_obj.job_id = job_id
-
-        new_obj._cpu_count = cpus
-        new_obj._memory_size = memory
-        new_obj._allocation_paradigm = paradigm
-        new_obj._allocation_priority = priority
-        new_obj._rsa_key_pair = rsa_key_pair
-        new_obj._status = status
-        new_obj._allocations = allocations
-        new_obj.data_requirements = cls._parse_serialized_data_requirements(json_obj)
-        new_obj._partition_config = partitioning
-
-        # Do last_updated last, as any usage of setters above might cause the value to be maladjusted
-        new_obj._last_updated = updated
-
-        return new_obj
-
-    def __init__(self, job_request: SchedulerRequestMessage):
-        self._originating_request = job_request
-        super().__init__(cpu_count=job_request.cpus, memory_size=job_request.memory,
-                         model_request=job_request.model_request,
-                         allocation_paradigm=job_request.allocation_paradigm)
-        self.data_requirements = self.model_request.data_requirements
-
-    @property
-    def model_request(self) -> ExternalRequest:
-        """
-        Get the underlying configuration for the model execution that is being requested.
-
-        Returns
-        -------
-        ExternalRequest
-            The underlying configuration for the model execution that is being requested.
-        """
-        return self.originating_request.model_request
-
-    @property
-    def originating_request(self) -> SchedulerRequestMessage:
-        """
-        The original request that resulted in the creation of this job.
-
-        Returns
-        -------
-        SchedulerRequestMessage
-            The original request that resulted in the creation of this job.
-        """
-        return self._originating_request
-
-    def to_dict(self) -> dict:
-        """
-        Get the representation of this instance as a dictionary or dictionary-like object (e.g., a JSON object).
-
-        {
-            "job_class" : "<class_name>",
-            "cpu_count" : 4,
-            "memory_size" : 1000,
-            "allocation_paradigm" : "SINGLE_NODE",
-            "allocation_priority" : 0,
-            "job_id" : "12345678-1234-5678-1234-567812345678",
-            "rsa_key_pair" : {<serialized_representation_of_RsaKeyPair_obj>},
-            "status" : INIT:DEFAULT,
-            "last_updated" : "2020-07-10 12:05:45",
-            "allocations" : [...],
-            'data_requirements" : [...],
-            "partitioning" : { "partitions": [ ... ] },
-            "originating_request" : {<serialized_representation_of_originating_message>}
-        }
-
-        Returns
-        -------
-        dict
-            the representation of this instance as a dictionary or dictionary-like object (e.g., a JSON object)
-        """
-        dictionary = super().to_dict()
-        # To avoid this being messy, rely on the superclass's implementation and the returned dict, but remove the
-        # 'model_request' key/value, since this is contained within the originating serialized scheduler request
-        dictionary.pop('model_request')
-        dictionary['originating_request'] = self.originating_request.to_dict()
-        return dictionary
+        # NOTE: consider refactoring this into `from_job_request` class method.
+        super().__init__(
+            cpu_count=job_request.cpus,
+            memory_size=job_request.memory,
+            model_request=job_request.model_request,
+            allocation_paradigm=job_request.allocation_paradigm,
+            originating_request=job_request,
+            )
+        # NOTE: this implicitly resets `last_updated` field
+        self.set_data_requirements(job_request.model_request.data_requirements)

--- a/python/lib/scheduler/dmod/scheduler/job/job.py
+++ b/python/lib/scheduler/dmod/scheduler/job/job.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from numbers import Number
-from pydantic import Field, validator, root_validator
+from functools import cache
+from pydantic import Field, PrivateAttr, validator, root_validator
 from pydantic.fields import ModelField
 from warnings import warn
 

--- a/python/lib/scheduler/dmod/scheduler/resources/resource.py
+++ b/python/lib/scheduler/dmod/scheduler/resources/resource.py
@@ -119,13 +119,7 @@ class SingleHostProcessingAssetPool(AbstractProcessingAssetPool, ABC):
     creation.
     """
 
-    def __init__(self, pool_id: str, hostname: str, cpu_count: int, memory: int):
-        super().__init__(pool_id=pool_id, cpu_count=cpu_count, memory=memory)
-        self._hostname = hostname
-
-    @property
-    def hostname(self) -> str:
-        return self._hostname
+    hostname: str
 
 
 class Resource(SingleHostProcessingAssetPool):

--- a/python/lib/scheduler/dmod/scheduler/resources/resource.py
+++ b/python/lib/scheduler/dmod/scheduler/resources/resource.py
@@ -2,14 +2,16 @@ from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Any, Dict, Optional, Tuple, Type, Union
 
+from dmod.core.enum import PydanticEnum
 
-class ResourceAvailability(Enum):
+
+class ResourceAvailability(PydanticEnum):
     ACTIVE = 1,
     INACTIVE = 2,
     UNKNOWN = -1
 
 
-class ResourceState(Enum):
+class ResourceState(PydanticEnum):
     READY = 1
     NOT_READY = 2,
     UNKNOWN = -1

--- a/python/lib/scheduler/dmod/scheduler/resources/resource.py
+++ b/python/lib/scheduler/dmod/scheduler/resources/resource.py
@@ -422,6 +422,19 @@ class Resource(SingleHostProcessingAssetPool):
         self.memory = self.memory + memory
 
     @property
+    def total_cpu_count(self) -> int:
+        """
+        The total number of CPUs known to be on this resource.
+        Returns
+        -------
+        int
+            The total number of CPUs known to be on this resource.
+        """
+        # NOTE: total cpus will be set or derived from `cpu_count`
+        return self.total_cpus # type: ignore
+
+
+    @property
     def resource_id(self) -> str:
         return self.pool_id
 

--- a/python/lib/scheduler/dmod/scheduler/resources/resource.py
+++ b/python/lib/scheduler/dmod/scheduler/resources/resource.py
@@ -146,63 +146,56 @@ class Resource(SingleHostProcessingAssetPool):
     are expected to never change for a resource.
     """
 
-    @classmethod
-    def factory_init_from_dict(cls, init_dict: dict, ignore_extra_keys: bool = False) -> 'Resource':
-        """
-        Initialize a new object from the given dictionary, raising a ::class:`ValueError` if there are missing expected
-        keys or there are extra keys when the method is not set to ignore them.
+    availability: ResourceAvailability
+    """
+    The availability of the resource.
 
-        Note that this method will allow ::class:`ResourceAvailability` and ::class:`ResourceState` values for the
-        init values of ``availability`` and ``state`` respectively, in addition to strings.  It will also convert
-        numeric types from string values appropriately.
+    Note that the property setter accepts both string and ::class:`ResourceAvailability` values.  For a string, the
+    argument is converted to a ::class:`ResourceAvailability` value using ::method:`get_resource_enum_value`.
 
-        Also, unlike other implementations, ``total cpus`` and ``total memory`` are expected keys, but they are not
-        required.  If they are not present, the defaults (the respective available values) are used by the initializer.
+    However, if the conversion of a string with ::method:`get_resource_enum_value` returns ``None``, the setter
+    sets ::attribute:`availability` to the ``UNKNOWN`` enum value, rather than ``None``.  This is more applicable
+    and allows the getter to always return an actual ::class:`ResourceAvailability` instance.
+    """
 
-        parent:
-        """
-        node_id = None
-        hostname = None
-        avail = None
-        state = None
-        cpus = None
-        total_cpus = None
-        memory = None
-        total_memory = None
+    state: ResourceState = Field(description="The readiness state of the resource.")
+    """
+    Note that the property setter accepts both string and ::class:`ResourceState` values.  For a string, the
+    argument is converted to a ::class:`ResourceState` value using ::method:`get_resource_enum_value`.
 
-        for param_key in init_dict:
-            # We don't care about non-string keys directly, but they are implicitly extra ...
-            if not isinstance(param_key, str):
-                if not ignore_extra_keys:
-                    raise ValueError("Unexpected non-string resource init key")
-                else:
-                    continue
-            lower_case_key = param_key.lower()
-            if lower_case_key == 'node_id' and node_id is None:
-                node_id = init_dict[param_key]
-            elif lower_case_key == 'hostname' and hostname is None:
-                hostname = init_dict[param_key]
-            elif lower_case_key == 'availability' and avail is None:
-                avail = init_dict[param_key]
-            elif lower_case_key == 'state' and state is None:
-                state = init_dict[param_key]
-            elif lower_case_key == 'cpus' and cpus is None:
-                cpus = int(init_dict[param_key])
-            elif lower_case_key == 'memorybytes' and memory is None:
-                memory = int(init_dict[param_key])
-            elif lower_case_key == 'total cpus' and total_cpus is None:
-                total_cpus = int(init_dict[param_key])
-            elif lower_case_key == 'total memory' and total_memory is None:
-                total_memory = int(init_dict[param_key])
-            elif not ignore_extra_keys:
-                raise ValueError("Unexpected resource init key (or case-insensitive duplicate) {}".format(param_key))
+    However, if the conversion of a string with ::method:`get_resource_enum_value` returns ``None``, the setter sets
+    ::attribute:`state` to the ``UNKNOWN`` enum value, rather than ``None``.  This is more applicable and allows the
+    getter to always return an actual ::class:`ResourceState` instance.
+    """
 
-        # Make sure we have everything required set
-        if node_id is None or hostname is None or cpus is None or memory is None or avail is None or state is None:
-            raise ValueError("Insufficient valid values keyed within resource init dictionary")
+    total_cpus: Optional[int] = Field(description="The total number of CPUs known to be on this resource.")
 
-        return cls(resource_id=node_id, hostname=hostname, availability=avail, state=state, cpu_count=cpus,
-                   memory=memory, total_cpu_count=total_cpus, total_memory=total_memory)
+    total_memory: Optional[int] = Field(description="The total amount of memory known to be on this resource.")
+
+    class Config:
+        fields = {
+            "availability": {"alias": "Availability"},
+            "cpu_count": {"alias": "CPUs"},
+            "hostname": {"alias": "Hostname"},
+            "memory": {"alias": "MemoryBytes"},
+            "pool_id": {"alias": "node_id"},
+            "state": {"alias": "State"},
+            "total_cpus": {"alias": "Total CPUs"},
+            "total_memory": {"alias": "Total Memory"},
+            "unique_id_separator": {"exclude": True}
+        }
+
+    @validator("availability", pre=True)
+    def _validate_availability(cls, value: Optional[Any]) -> Union[Any, ResourceAvailability]:
+        if value is None:
+            return ResourceAvailability.UNKNOWN
+        return value
+
+    @validator("state", pre=True)
+    def _validate_state(cls, value: Optional[Any]) -> Union[Any, ResourceState]:
+        if value is None:
+            return ResourceState.UNKNOWN
+        return value
 
     @classmethod
     def generate_unique_id(cls, resource_id: str, separator: str):
@@ -220,7 +213,7 @@ class Resource(SingleHostProcessingAssetPool):
         str
             The derived unique id.
         """
-        return cls.__name__ + separator + resource_id
+        return f"{cls.__name__}{separator}{resource_id}"
 
     @classmethod
     def get_cpu_hash_key(cls) -> str:
@@ -232,7 +225,7 @@ class Resource(SingleHostProcessingAssetPool):
         str
             The hash key value for serialized dictionaries/hashes representations.
         """
-        return 'CPUs'
+        return "CPUs"
 
     @classmethod
     def get_resource_enum_value(cls, enum_type: Union[Type[ResourceAvailability], Type[ResourceState]],
@@ -269,7 +262,8 @@ class Resource(SingleHostProcessingAssetPool):
                 return val
         return None
 
-    def __eq__(self, other):
+
+    def __eq__(self, other: object):
         if not isinstance(other, Resource):
             return super().__eq__(other)
         else:
@@ -278,19 +272,32 @@ class Resource(SingleHostProcessingAssetPool):
                    and self.cpu_count == other.cpu_count and self.memory == other.memory \
                    and self.total_cpu_count == other.total_cpu_count and self.total_memory == other.total_memory
 
-    def __init__(self, resource_id: str, hostname: str, availability: Union[str, ResourceAvailability],
-                 state: Union[str, ResourceState], cpu_count: int, memory: int, total_cpu_count: Optional[int],
-                 total_memory: Optional[int]):
-        super().__init__(pool_id=resource_id, hostname=hostname, cpu_count=cpu_count, memory=memory)
+    def __init__(
+        self,
+        resource_id: str = None,
+        hostname: str = None,
+        availability: Union[str, ResourceAvailability] = None,
+        state: Union[str, ResourceState] = None,
+        cpu_count: int = None,
+        memory: int = None,
+        total_cpu_count: Optional[int] = None,
+        total_memory: Optional[int] = None,
+        **data
+        ):
+        if data:
+            super().__init__(**data)
+            return
 
-        self._availability = None
-        self.availability = availability
-
-        self._state = state
-        self.state = state
-
-        self._total_cpu_count = cpu_count if total_cpu_count is None else total_cpu_count
-        self._total_memory = memory if total_memory is None else total_memory
+        super().__init__(
+            pool_id=resource_id,
+            hostname=hostname,
+            cpu_count=cpu_count,
+            memory=memory,
+            availability=availability,
+            state=state,
+            total_cpu_count=cpu_count if total_cpu_count is None else total_cpu_count,
+            total_memory=memory if total_memory is None else total_memory,
+            )
 
     def allocate(self, cpu_count: int, memory: int) -> Tuple[int, int, bool]:
         """
@@ -333,32 +340,12 @@ class Resource(SingleHostProcessingAssetPool):
             self.memory = 0
         return allocated_cpus, allocated_mem, is_fully_allocated
 
-    @property
-    def availability(self) -> ResourceAvailability:
-        """
-        The availability of the resource.
-
-        Note that the property setter accepts both string and ::class:`ResourceAvailability` values.  For a string, the
-        argument is converted to a ::class:`ResourceAvailability` value using ::method:`get_resource_enum_value`.
-
-        However, if the conversion of a string with ::method:`get_resource_enum_value` returns ``None``, the setter
-        sets ::attribute:`availability` to the ``UNKNOWN`` enum value, rather than ``None``.  This is more applicable
-        and allows the getter to always return an actual ::class:`ResourceAvailability` instance.
-
-        Returns
-        -------
-        ResourceAvailability
-            The availability of the resource.
-        """
-        return self._availability
-
-    @availability.setter
-    def availability(self, availability: Union[str, ResourceAvailability]):
+    def set_availability(self, availability: Union[str, ResourceAvailability]):
         if isinstance(availability, ResourceAvailability):
             enum_val = availability
         else:
             enum_val = self.get_resource_enum_value(ResourceAvailability, availability)
-        self._availability = ResourceAvailability.UNKNOWN if enum_val is None else enum_val
+        self.__dict__["availability"] = ResourceAvailability.UNKNOWN if enum_val is None else enum_val
 
     def is_allocatable(self) -> bool:
         """
@@ -396,85 +383,48 @@ class Resource(SingleHostProcessingAssetPool):
     def resource_id(self) -> str:
         return self.pool_id
 
-    @property
-    def state(self) -> ResourceState:
-        """
-        The readiness state of the resource.
-
-        Note that the property setter accepts both string and ::class:`ResourceState` values.  For a string, the
-        argument is converted to a ::class:`ResourceState` value using ::method:`get_resource_enum_value`.
-
-        However, if the conversion of a string with ::method:`get_resource_enum_value` returns ``None``, the setter sets
-        ::attribute:`state` to the ``UNKNOWN`` enum value, rather than ``None``.  This is more applicable and allows the
-        getter to always return an actual ::class:`ResourceState` instance.
-
-        Returns
-        -------
-        ResourceState
-            The readiness state of the resource.
-        """
-        return self._state
-
-    @state.setter
-    def state(self, state: Union[str, ResourceState]):
+    def set_state(self, state: Union[str, ResourceState]):
         if isinstance(state, ResourceState):
             enum_val = state
         else:
             enum_val = self.get_resource_enum_value(ResourceState, state)
-        self._state = ResourceState.UNKNOWN if enum_val is None else enum_val
-
-    def to_dict(self) -> Dict[str, Union[str, int]]:
-        """
-        Convert the object to a serialized dictionary.
-
-        Key names are as shown in the example below.  Enum values are represented as the lower-case version of the name
-        for the given value.  Values shown for CPU and Memory are the max values.
-
-        E.g.:
-            {
-                'node_id': "Node-0001",
-                'Hostname': "my-host",
-                'Availability': "active",
-                'State': "ready",
-                'CPUs': 18,
-                'MemoryBytes': 33548128256,
-                'Total CPUs': 18,
-                'Total Memory: 33548128256
-            }
-
-        Returns
-        -------
-        Dict[str, Union[str, int]]
-            The object as a serialized dictionary.
-        """
-        return {'node_id': self.resource_id, 'Hostname': self.hostname, 'Availability': self.availability.name.lower(),
-                'State': self.state.name.lower(), self.get_cpu_hash_key(): self.cpu_count, 'MemoryBytes': self.memory,
-                'Total CPUs': self.total_cpu_count, 'Total Memory': self.total_memory}
-
-    @property
-    def total_cpu_count(self) -> int:
-        """
-        The total number of CPUs known to be on this resource.
-
-        Returns
-        -------
-        int
-            The total number of CPUs known to be on this resource.
-        """
-        return self._total_cpu_count
-
-    @property
-    def total_memory(self) -> int:
-        """
-        The total amount of memory known to be on this resource.
-
-        Returns
-        -------
-        int
-            The total amount of memory known to be on this resource.
-        """
-        return self._total_memory
+        self.__dict__["state"] = ResourceState.UNKNOWN if enum_val is None else enum_val
 
     @property
     def unique_id(self) -> str:
         return self.generate_unique_id(resource_id=self.resource_id, separator=self.unique_id_separator)
+
+    def _setter_methods(self) -> Dict[str, Callable]:
+        """Mapping of attribute name to setter method. This supports backwards functional compatibility."""
+        # TODO: remove once migration to setters by down stream users is complete
+        return {
+            "state": self.set_state,
+            "availability": self.set_availability,
+            }
+
+    def __setattr__(self, name: str, value: Any):
+        """
+        Use property setter method when available.
+
+        Note, all setter methods should modify their associated property using the instance `__dict__`.
+        This ensures that calls to, for example, `set_id` don't raise a warning, while `o.id = "new
+        id"` do.
+
+        Example:
+            ```
+            class SomeJob(Job):
+                id: str
+
+                def set_id(self, value: str):
+                    self.__dict__["id"] = value
+            ```
+        """
+        if name not in self._setter_methods():
+            return super().__setattr__(name, value)
+
+        setter_fn = self._setter_methods()[name]
+
+        message = f"Setting by attribute is deprecated. Use `{self.__class__.__name__}.{setter_fn.__name__}` method instead."
+        warn(message, DeprecationWarning)
+
+        setter_fn(value)

--- a/python/lib/scheduler/dmod/scheduler/resources/resource.py
+++ b/python/lib/scheduler/dmod/scheduler/resources/resource.py
@@ -220,6 +220,14 @@ class Resource(SingleHostProcessingAssetPool):
 
         if values.get("total_memory") is None:
             values["total_memory"] = values["memory"]
+
+        msg_template = "`{}` cannot be larger than `{}`. {} > {}"
+        if values["cpu_count"] > values["total_cpus"]:
+            raise ValueError(msg_template.format("cpu_count", "total_cpus", values["cpu_count"], values["total_cpus"]))
+
+        if values["memory"] > values["total_memory"]:
+            raise ValueError(msg_template.format("memory", "total_memory", values["memory"], values["total_memory"]))
+
         return values
 
     @classmethod

--- a/python/lib/scheduler/dmod/scheduler/rsa_key_pair.py
+++ b/python/lib/scheduler/dmod/scheduler/rsa_key_pair.py
@@ -271,6 +271,7 @@ class RsaKeyPair(_RsaKeyPair, Serializable):
 
     class Config: # type: ignore
         arbitrary_types_allowed = True
+        validate_assignment = True
         def _serialize_datetime(self: "RsaKeyPair", value: datetime.datetime) -> str:
             return value.strftime(self.get_datetime_str_format())
 

--- a/python/lib/scheduler/dmod/scheduler/rsa_key_pair.py
+++ b/python/lib/scheduler/dmod/scheduler/rsa_key_pair.py
@@ -3,29 +3,235 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.backends import default_backend
 from dmod.core.serializable import Serializable
 from pathlib import Path
-from typing import Dict, Union
+from pydantic import Field, PrivateAttr, validator
+from typing import ClassVar, Dict, Optional, Tuple, Union
+from typing_extensions import Self
 import datetime
 import os
 
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKeyWithSerialization
 
+class _RsaKeyPair(Serializable):
+    """
+    This is a shim object that enables partial instantiation of a :class:`RsaKeyPair`. This class exposes methods and
+    properties to interact, generate, and write a key pair. However, it does not expose a way to serialize or
+    deserialize keys and other associated metadata from a dictionary. For the functionality, see :class:`RsaKeyPair`.
+    """
 
-class RsaKeyPair(Serializable):
+    directory: Path
+    """
+    The directory in which the key pair files have been or will be written, as a :class:`Path`.
+
+    If `None` is provided, `directory` defaults to ``$HOME/.ssh/``. If the default or provided directory does not
+    exists, it and any intermediate directories will be created. Directory inputs that exist and are not directories
+    (i.e. a file) will raise a ValueError.
+    """
+
+    name: str = Field(min_length=1)
+    """Basename of private key file."""
+
+    _priv_key: RSAPrivateKeyWithSerialization = PrivateAttr(None)
+    _priv_key_pem: bytes = PrivateAttr(None)
+    _is_deserialized: bool = PrivateAttr(False)
+
+    @validator("directory", pre=True)
+    def _validate_directory(cls, value: Union[str, Path, None]) -> Union[str, Path]:
+        if value is None:
+            return Path.home() / ".ssh"
+
+        if isinstance(value, str):
+            return value.strip()
+
+        return value
+
+    @validator("directory")
+    def _post_validate_directory(cls, value: Path) -> Path:
+        if not value.exists():
+            value.mkdir(parents=True)
+
+        elif not value.is_dir():
+            raise ValueError(f"Existing non-directory file at path provided for key pair directory. {value!r}")
+
+        return value
+
+    @validator("name")
+    def _validate_name(cls, value: str) -> str:
+        return value.strip()
+
+    @property
+    def private_key_file(self) -> Path:
+        """
+
+        Returns
+        -------
+        Path
+            Path to private key file. Is not guaranteed to exist.
+        """
+        return self.directory / self.name
+
+    @property
+    def public_key_file(self) -> Path:
+        """
+        Same as private key filepath, but with the suffix ".pub".
+
+        Returns
+        -------
+        Path
+            Path to public key file. Is not guaranteed to exist.
+        """
+        return self.directory / f"{self.name}.pub"
+
+    @property
+    def private_key_pem(self) -> bytes:
+        """
+
+        Returns
+        -------
+        bytes
+            Encoded private key in PEM format
+        """
+        if self._priv_key_pem is None:
+            self._priv_key_pem = self._private_key_bytes_from_private_key(self._private_key)
+        return self._priv_key_pem # type: ignore
+
+    def delete_key_files(self) -> Tuple[bool, bool]:
+        """
+        Delete the files at the paths specified by :attr:`private_key_file` and :attr:`public_key_file`, as long as
+        there is an existing, regular (i.e., from :method:`Path.is_file`) file at the individual paths.
+
+        Note that whether a delete is performed for one file is independent of what the state of the other.  I.e., if
+        the private key file does not exist, thus resulting in no attempt to delete it, this will not affect whether
+        there is a delete operation on the public key file.
+
+        Returns
+        -------
+        tuple
+            A tuple of boolean values, representing whether the private key file and the public key file respectively
+            were deleted
+        """
+        deleted_private = False
+        deleted_public = False
+        if self.private_key_file.exists() and self.private_key_file.is_file():
+            self.private_key_file.unlink()
+            deleted_private = True
+        if self.public_key_file.exists() and self.public_key_file.is_file():
+            self.public_key_file.unlink()
+            deleted_public = True
+        return deleted_private, deleted_public
+
+    def write_key_files(self, write_private: bool = True, write_public: bool = True):
+        """
+        Write private and/or public keys to files at :attr:`private_key_file` and :attr:`public_key_file` respectively,
+        assuming the respective file does not already exist.
+
+        Parameters
+        ----------
+        write_private : bool
+            An option, ``True`` by default, for whether the private key should be written to :attr:`private_key_file`
+
+        write_public : bool
+            An option, ``True`` by default, for whether the public key should be written to :attr:`public_key_file`
+        """
+        # if fail to write private key file, delete any existing pub / priv key files.
+        try:
+            if write_private and not self.private_key_file.exists():
+                self._write_private_key(self._private_key, raise_on_fail=True)
+        except Exception as e:
+            if self.public_key_file.exists():
+                _, deleted_public = self.delete_key_files()
+                if not deleted_public:
+                    raise RuntimeError(f"Failed to write private key file. During failure, failed to remove public key file. '{self.public_key_file}'") from e
+            raise e
+
+        # NOTE: if cannot write pub key file, priv key file, if it exists, will not be removed.
+        if write_public and not self.public_key_file.exists():
+            self._write_public_key(self._private_key, raise_on_fail=True)
+
+    @property
+    def _private_key(self) -> RSAPrivateKeyWithSerialization:
+        """
+        Serialized private key. Lazily loads private key from :property:`private_key_file` or dynamically generates one.
+
+        If the private key is loaded from :property:`private_key_file` and :property:`public_key_file` does not exist, a
+        public key is written to disk at :property:`public_key_file`.
+        """
+        if self._priv_key is None and self.private_key_file.exists():
+            priv_key_file = self.private_key_file.read_bytes()
+            self._priv_key = serialization.load_pem_private_key(priv_key_file, None, default_backend())
+            self._is_deserialized = True
+
+            self._write_public_key(self._priv_key, overwrite=False, raise_on_fail=True)
+
+        elif self._priv_key is None:
+            self._priv_key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=3072)
+
+        return self._priv_key # type: ignore
+
+    @staticmethod
+    def _public_key_bytes_from_private_key(private_key: RSAPrivateKeyWithSerialization) -> bytes:
+        return private_key.public_key().public_bytes(serialization.Encoding.OpenSSH, serialization.PublicFormat.OpenSSH)
+
+    @staticmethod
+    def _private_key_bytes_from_private_key(private_key:  RSAPrivateKeyWithSerialization) -> bytes:
+        return private_key.private_bytes(encoding=serialization.Encoding.PEM,
+                                         format=serialization.PrivateFormat.TraditionalOpenSSL,
+                                         encryption_algorithm=serialization.NoEncryption())
+
+    @staticmethod
+    def _read_private_key_ctime(location: Path) -> datetime.datetime:
+        return datetime.datetime.fromtimestamp(os.path.getctime(str(location)))
+
+    @staticmethod
+    def __try_write(content: str, location: Path, overwrite: bool = False, raise_on_fail: bool = False) -> bool:
+        if not overwrite and location.exists():
+            return False
+        try:
+            location.write_text(content)
+        except Exception as e:
+            if raise_on_fail:
+                raise e
+            return False
+        return True
+
+    def _write_public_key(self, private_key: RSAPrivateKeyWithSerialization, overwrite: bool = False, raise_on_fail: bool = False) -> bool:
+        pub_key = self._public_key_bytes_from_private_key(private_key).decode("utf-8")
+        return self.__try_write(pub_key, self.public_key_file, overwrite=overwrite, raise_on_fail=raise_on_fail)
+
+    def _write_private_key(self, private_key: RSAPrivateKeyWithSerialization, overwrite: bool = False, raise_on_fail: bool = False) -> bool:
+        priv_key = self._private_key_bytes_from_private_key(private_key).decode("utf-8")
+        return self.__try_write(priv_key, self.private_key_file, overwrite=overwrite, raise_on_fail=raise_on_fail)
+
+    def _delete_existing_key_files_if_priv_keys_differ(self):
+        # Remove any existing private/public key files unless the contents match serialized private key value
+        if self.private_key_file.exists():
+            priv_key_file_bytes = self.private_key_file.read_bytes()
+
+            if priv_key_file_bytes != self._private_key_bytes_from_private_key(self._private_key):
+                self.public_key_file.unlink(missing_ok=True)
+                self.private_key_file.unlink()
+                raise RuntimeError("Existing private key from file does not match provided private.")
+
+        elif self.public_key_file.exists():
+            # Always remove an existing public key file if there was not a private key file
+            self.public_key_file.unlink()
+
+
+class RsaKeyPair(_RsaKeyPair, Serializable):
     """
     Representation of an RSA key pair and certain meta properties, in particular a name for the key and a pair of
     :class:`Path` objects for its private and public key files. Keys may be either dynamically generated or deserialized
     from existing files.
 
     Key file basenames are derived from the :attr:`name` value for the object, which is set from an init param that
-    defaults to ``id_rsa`` if not provided.  The public key file will have the same basename as the private key file,
-    except with the ``.pub`` extension added.
+    defaults to ``id_rsa`` if not provided. However, :attr:`name` is a required field when initializing from a
+    dictionary. The public key file will have the same basename as the private key file, except with the ``.pub``
+    extension added.
 
     When the private key file already exists, the private key will be deserialized from the file contents.  This will
     happen immediately when the object is created.
 
-    When the private key file does not already exists, the actual keys will be generated dynamically, though this is
-    performed lazily.  The :method:`generate_key_pair` method will trigger all necessary lazy instantiations and also
-    cause the key files to be written.
+    When the private key file does not already exists, the actual keys will be generated dynamically -- but not written
+    to a file. Use the :method:`write_key_files` to write key pairs to a file.
 
     Note that rich comparisons for ``==`` and ``<`` are expressly defined, with the other implementations being derived
     from these two.
@@ -34,19 +240,48 @@ class RsaKeyPair(Serializable):
         # The basename of the private key file will always be the key pair's name
         self.name == self.private_key_file.name
 
-        # The returned generation time property value will always be equal to the time stamp of the private key file
-        self.generation_time == datetime.datetime.fromtimestamp(os.path.getctime(str(self.private_key_file)))
-
     """
-    _SERIAL_DATETIME_STR_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
-    _SERIAL_KEY_DIRECTORY = 'directory'
-    _SERIAL_KEY_NAME = 'name'
-    _SERIAL_KEY_PRIVATE_KEY = 'private_key'
-    _SERIAL_KEY_GENERATION_TIME = 'generation_time'
-    _SERIAL_KEYS_REQUIRED = [_SERIAL_KEY_NAME, _SERIAL_KEY_DIRECTORY, _SERIAL_KEY_PRIVATE_KEY, _SERIAL_KEY_GENERATION_TIME]
+
+    private_key: RSAPrivateKeyWithSerialization
+    """
+    Serialized private key for this key pair object.
+    """
+
+    generation_time: datetime.datetime
+
+    _pub_key: bytes = PrivateAttr(None)
+    __private_key_text: str = PrivateAttr(None)
+
+    _SERIAL_DATETIME_STR_FORMAT: ClassVar[str] = '%Y-%m-%d %H:%M:%S.%f'
+
+    @validator("generation_time", pre=True)
+    def _validate_datetime(cls, value: Union[str, datetime.datetime]) -> datetime.datetime:
+        if isinstance(value, datetime.datetime):
+            return value
+
+        return datetime.datetime.strptime(value, cls.get_datetime_str_format())
+
+    @validator("private_key", pre=True)
+    def _validate_private_key(cls, value: Union[str, RSAPrivateKeyWithSerialization ]) -> RSAPrivateKeyWithSerialization:
+        if isinstance(value, RSAPrivateKeyWithSerialization):
+            return value
+
+        priv_key_bytes = value.encode("utf-8")
+        return serialization.load_pem_private_key(priv_key_bytes, None, default_backend())
+
+    class Config: # type: ignore
+        arbitrary_types_allowed = True
+        def _serialize_datetime(self: "RsaKeyPair", value: datetime.datetime) -> str:
+            return value.strftime(self.get_datetime_str_format())
+
+        field_serializers = {
+            "generation_time": _serialize_datetime,
+            "private_key": lambda self, _: self._private_key_text,
+            "directory": lambda directory: str(directory),
+        }
 
     @classmethod
-    def factory_init_from_deserialized_json(cls, json_obj: Dict[str, str]):
+    def factory_init_from_deserialized_json(cls, json_obj: Dict[str, str]) -> Optional[Self]:
         """
         Factory create a new instance of this type based on a JSON object dictionary deserialized from received JSON.
 
@@ -73,204 +308,104 @@ class RsaKeyPair(Serializable):
         err_msg_start = 'Cannot deserialize {} object'.format(cls.__name__)
         try:
             # Sanity check serialized structure
-            for key in cls._SERIAL_KEYS_REQUIRED:
-                if key not in json_obj:
-                    raise RuntimeError('{}: missing required serial {} key'.format(err_msg_start, key))
-            # Parse the generation time
-            gen_time_str = json_obj[cls._SERIAL_KEY_GENERATION_TIME]
-            try:
-                gen_time_val = datetime.datetime.strptime(gen_time_str, cls.get_datetime_str_format())
-            except:
-                raise RuntimeError('{}: invalid format for generation time ({})'.format(err_msg_start, gen_time_str))
-            # Create the instance, passing serialize values for directory and name
-            try:
-                new_obj = RsaKeyPair(directory=json_obj[cls._SERIAL_KEY_DIRECTORY], name=json_obj[cls._SERIAL_KEY_NAME])
-            except ValueError as ve:
-                raise RuntimeError('{}: problem with directory - {}'.format(err_msg_start, str(ve)))
-            # Manually set the generation time attribute
-            new_obj._generation_time = gen_time_val
-            # Set the private key value from serialized data
-            priv_key_str = json_obj[cls._SERIAL_KEY_PRIVATE_KEY]
-            priv_key_bytes = priv_key_str.encode('utf-8')
-            new_obj._priv_key = serialization.load_pem_private_key(priv_key_bytes, None, default_backend())
-            # Remove any existing private/public key files unless the contents match serialized private key value
-            if new_obj.private_key_file.exists():
-                try:
-                    with new_obj.private_key_file.open('rb') as priv_key_file:
-                        priv_key_file_bytes = priv_key_file.read()
-                        if priv_key_file_bytes != priv_key_bytes:
-                            raise RuntimeError('clear key file')
-                except:
-                    new_obj.public_key_file.unlink(missing_ok=True)
-                    new_obj.private_key_file.unlink()
-            elif new_obj.public_key_file.exists():
-                # Always remove an existing public key file if there was not a private key file
-                new_obj.public_key_file.unlink()
-            # Finally, return the instance
-            return new_obj
+            for field in cls.__fields__.values():
+                if field.alias not in json_obj:
+                    raise RuntimeError('{}: missing required serial {} key'.format(err_msg_start, field.alias))
 
-        except RuntimeError as e:
+            o = cls(**json_obj)
+            o._is_deserialized = True
+            return o
+        except:
             # TODO: log error
             return None
 
-    def __eq__(self, other: 'RsaKeyPair') -> bool:
+    def __eq__(self, other: Self) -> bool:
         return other is not None \
                and self.generation_time == other.generation_time \
-               and self._get_private_key_text() == other._get_private_key_text() \
+               and self._private_key_text == other._private_key_text \
                and self.private_key_file.absolute() == other.private_key_file.absolute()
 
-    def __ge__(self, other):
+    def __ge__(self, other: Self):
         return not self < other
 
-    def __gt__(self, other):
+    def __gt__(self, other: Self):
         return not self <= other
 
-    def __init__(self, directory: Union[str, Path, None], name: str = 'id_rsa'):
+    def __init__(self, directory: Union[str, Path, None], name: str = "id_rsa", **data):
         """
         Initialize an instance.
-
-        Initializing an instance, setting the ``directory`` and ``name`` properties, and creating the other required
-        backing attributes used by the object, setting them to ``None`` (except for ::attribute:`_files_written`, which
-        is set to ``False``.
 
         Parameters
         ----------
         directory : str, Path, None
             The path (either as a :class:`Path` or string) to the parent directory for the backing key files, or
-            ``None`` if the default of ``.ssh/`` in the user's home directory should be used.
+            ``None`` if the default of ``{$HOME}/.ssh/`` should be used.
 
         name : str
             The name to use for the key pair, which will also be the basename of the private key file and the basis of
             the basename of the public key file (``id_rsa`` by default).
         """
-        self._name = name.strip()
-        if self._name is None or len(self._name) < 1:
-            raise ValueError("Invalid key pair name")
+        # If `data` exists, we assume we are deserializing a message with all required fields.
+        # NOTE: method, `factory_init_from_deserialized_json`, verifies that all fields are passed
+        # before trying to initialize.
+        if data:
+            super().__init__(
+                directory=directory,
+                name=name,
+                **data
+            )
+            # indirectly set `_private_key` property of parent class `_RsaKeyPair`.
+            # as a result a public key file will not be created during initialization even if a
+            # private key file exists and its contents match the passed `private_key` field and a
+            # public key file does not exist.
+            self._priv_key = self.private_key
+            self._delete_existing_key_files_if_priv_keys_differ()
 
-        self.directory = directory
+        # If `data` does not exists, partially initialize using fields we have, then derive / create
+        # all required byt unspecified fields. Then, fully initialize.
+        else:
+            key_pair = _RsaKeyPair(directory=directory, name=name)
+            # lazily generate or load private key
+            private_key = key_pair._private_key
+            # could raise `RuntimeError`
+            key_pair._delete_existing_key_files_if_priv_keys_differ()
+            key_pair.write_key_files()
+            generation_time = key_pair._read_private_key_ctime(key_pair.private_key_file)
 
-        self._public_key_file = None
-        self._private_key_file = None
+            super().__init__(
+                directory=directory,
+                name=name,
+                private_key=private_key,
+                generation_time=generation_time,
+            )
 
-        self._priv_key = None
-        self._priv_key_pem = None
-        self._pub_key = None
-
-        self._private_key_text = None
-        self._public_key_text = None
-
-        self._is_deserialized = None
-        self._generation_time = None
-        self._files_written = False
-        # Track whether actually in the process of writing something already, to not double-write during lazy load
-        self._is_writing_private_file = False
-        self._is_writing_public_file = False
+            # transfer how the key pair was created
+            self._is_deserialized = key_pair._is_deserialized
+            # no one should access this directly nor through property, `_private_key`, but just in case.
+            self._priv_key = self.private_key
 
     def __hash__(self) -> int:
-        hash_str = '{}:{}:{}'.format(self._get_private_key_text(),
+        hash_str = '{}:{}:{}'.format(self._private_key_text,
                                      str(self.private_key_file.absolute()),
                                      self.generation_time.strftime(self.get_datetime_str_format()))
-        return hash_str.__hash__()
+        return hash(hash_str)
 
-    def __le__(self, other: 'RsaKeyPair') -> bool:
+    def __le__(self, other: Self) -> bool:
         return self == other or self < other
 
-    def __lt__(self, other: 'RsaKeyPair') -> bool:
+    def __lt__(self, other: Self) -> bool:
         if self.generation_time != other.generation_time:
             return self.generation_time < other.generation_time
-        elif self._get_private_key_text != other._get_private_key_text:
-            return self._get_private_key_text < other._get_private_key_text
+        elif self._private_key_text != other._private_key_text:
+            return self._private_key_text < other._private_key_text
         else:
             return self.private_key_file.absolute() < other.private_key_file.absolute()
 
-    def _get_private_key_text(self):
-        if self._private_key_text is None:
-            self._load_key_text()
-        return self._private_key_text
-
-    def _load_key_text(self):
-        if self._private_key_text is None:
-            self._private_key_text = self.private_key_pem.decode('utf-8')
-        if self._public_key_text is None:
-            self._public_key_text = self.public_key.decode('utf-8')
-
-    def _read_private_key_ctime(self, skip_file_exists_check=False):
-        if skip_file_exists_check or self.private_key_file.exists():
-            return datetime.datetime.fromtimestamp(os.path.getctime(str(self.private_key_file)))
-        else:
-            return None
-
-    def delete_key_files(self) -> tuple:
-        """
-        Delete the files at the paths specified by :attr:`private_key_file` and :attr:`public_key_file`, as long as
-        there is an existing, regular (i.e., from :method:`Path.is_file`) file at the individual paths.
-
-        Note that whether a delete is performed for one file is independent of what the state of the other.  I.e., if
-        the private key file does not exist, thus resulting in no attempt to delete it, this will not affect whether
-        there is a delete operation on the public key file.
-
-        Returns
-        -------
-        tuple
-            A tuple of boolean values, representing whether the private key file and the public key file respectively
-            were deleted
-        """
-        deleted_private = False
-        deleted_public = False
-        if self.private_key_file.exists() and self.private_key_file.is_file():
-            self.private_key_file.unlink()
-            deleted_private = True
-        if self.public_key_file.exists() and self.public_key_file.is_file():
-            self.public_key_file.unlink()
-            deleted_public = True
-        return deleted_private, deleted_public
-
     @property
-    def directory(self) -> Path:
-        """
-        The directory in which the key pair files have been or will be written, as a :class:`Path`.
-
-        The property getter will lazily instantiate the backing attribute to ``<USER_HOME>/.ssh/`` if the attribute is
-        set to ``None``.  This is done using the property setter function, thus triggering its potential side effects.
-
-        The property setter will accept string or ::class:`Path` objects, as well as ``None``.
-
-        The setter may, as a side effect, create the directory represented by the argument in the filesystem.  This is
-        done in cases when a valid argument other than ``None`` is received, and no file or directory currently exists
-        in the file system at that path. For string arguments, the string is first stripped of whitespace and converted
-        to a ::class:`Path` object before checking if the directory should be created. All of this logic is executed
-        before setting the backing attribute, so if an error is raised, then the attribute value will not be modified.
-
-        In particular, if the setter receives an argument representing a path to an existing, non-directory file, then a
-        the setter will raise ::class:`ValueError`, and the attribute will remain unchanged.
-
-        Returns
-        -------
-        Path
-            The directory in which the key pair files have been or will be written
-        """
-        if self._directory is None:
-            self.directory = Path.home().joinpath(".ssh")
-        return self._directory
-
-    @directory.setter
-    def directory(self, d: Union[str, Path, None]):
-        # Make sure we are working with either None or the equivalent Path object for a path as a string
-        d_path = Path(d.strip()) if isinstance(d, str) else d
-        if d_path is not None:
-            if not d_path.exists():
-                d_path.mkdir()
-            elif not d_path.is_dir():
-                raise ValueError("Existing non-directory file at path provided for key pair directory")
-        self._directory = d_path
-
-    @property
-    def generation_time(self):
-        if self._generation_time is None:
-            if not self.private_key_file.exists():
-                self.write_key_files()
-            self._generation_time = self._read_private_key_ctime(skip_file_exists_check=True)
-        return self._generation_time
+    def _private_key_text(self) -> str:
+        if self.__private_key_text is None:
+            self.__private_key_text = self.private_key_pem.decode("utf-8")
+        return self.__private_key_text # type: ignore
 
     @property
     def is_deserialized(self) -> bool:
@@ -278,159 +413,21 @@ class RsaKeyPair(Serializable):
         Whether this object was deserialized from an already-existing file or serialized object, as opposed to being
         created and dynamically generating its keys.
 
-        pre: self._is_deserialized is not None or self._priv_key is None
-
-        post: self._is_deserialized is not None and self._priv_key is not None
-
         Returns
         -------
         bool
             Whether this object was created from a pre-existing private key file
         """
-        if self._is_deserialized is None:
-            # We don't actually need the value directly, but the lazy instantiation will set _is_deserialized as a side-
-            # effect, since it intrinsically has to determine whether it can/should deserialized the private key
-            priv_key = self.private_key
         return self._is_deserialized
 
     @property
-    def name(self):
-        return self._name
-
-    @property
-    def private_key(self) -> RSAPrivateKeyWithSerialization:
-        """
-        Get the private key for this key pair object, lazily instantiating if necessary either through deserialization
-        or by dynamically generating a key.
-
-        Note that, since lazy instantiation requires determining if the value should be deserialized, the attribute
-        backing the :attr:`is_deserialized` property is set as a side effect when performing that step.
-
-        post: self._is_deserialized is not None
-
-        Returns
-        -------
-        RSAPrivateKeyWithSerialization
-            The actual RSA private key object
-        """
-        if self._priv_key is None and self.private_key_file.exists():
-            with self.private_key_file.open('rb') as priv_key_file:
-                self._priv_key = serialization.load_pem_private_key(priv_key_file.read(), None, default_backend())
-                if not self.public_key_file.exists():
-                    self.write_key_files(write_private=False)
-                self._files_written = True
-                self._is_deserialized = True
-        elif self._priv_key is None:
-            self._priv_key = rsa.generate_private_key(backend=default_backend(), public_exponent=65537, key_size=3072)
-        return self._priv_key
-
-    @property
-    def private_key_file(self) -> Path:
-        """
-        Get the path to the private key file, lazily instantiating using the :attr:`name` and :method:`directory`.
-
-        Returns
-        -------
-        Path
-            The path to the private key file
-        """
-        if self._private_key_file is None:
-            self._private_key_file = None if self.directory is None else self.directory.joinpath(self._name)
-        return self._private_key_file
-
-    @property
-    def private_key_pem(self):
-        if self._priv_key_pem is None:
-            self._priv_key_pem = self.private_key.private_bytes(encoding=serialization.Encoding.PEM,
-                                                                format=serialization.PrivateFormat.TraditionalOpenSSL,
-                                                                encryption_algorithm=serialization.NoEncryption())
-        return self._priv_key_pem
-
-    @property
-    def public_key(self):
+    def public_key(self) -> bytes:
         if self._pub_key is None:
-            self._pub_key = self.private_key.public_key().public_bytes(serialization.Encoding.OpenSSH,
-                                                                       serialization.PublicFormat.OpenSSH)
+            self._pub_key = self._public_key_bytes_from_private_key(self.private_key)
         return self._pub_key
 
-    @property
-    def public_key_file(self) -> Path:
-        """
-        Get the path to the public key file, lazily instantiating based on the :attr:`name` and :method:`directory`.
-
-        Returns
-        -------
-        Path
-            The path to the public key file
-        """
-        if self._public_key_file is None:
-            self._public_key_file = None if self.directory is None else self.directory.joinpath(self._name + '.pub')
-        return self._public_key_file
-
-    def to_dict(self) -> Dict[str, str]:
-        """
-        Serialize to a dictionary representation of string keys and values.
-
-        The format is as follows:
-
-            {
-                'name': 'name_value',
-                'directory': 'directory_path_as_string',
-                'private_key': 'private_key_text',
-                'generation_time': 'generation_time_str'
-            }
-
-        Returns
-        -------
-        Dict[str, str]
-            The serialized form of this instance as a dictionary object with string keys and string values.
-        """
-        return {
-            self._SERIAL_KEY_NAME: self.name,
-            self._SERIAL_KEY_DIRECTORY: str(self.directory),
-            self._SERIAL_KEY_PRIVATE_KEY: self._get_private_key_text(),
-            self._SERIAL_KEY_GENERATION_TIME: self.generation_time.strftime(self.get_datetime_str_format())
-        }
-
-    def write_key_files(self, write_private=True, write_public=True):
-        """
-        Write private and/or public keys to files at :attr:`private_key_file` and :attr:`public_key_file` respectively,
-        assuming the respective file does not already exist.
-
-        Parameters
-        ----------
-        write_private : bool
-            An option, ``True`` by default, for whether the private key should be written to :attr:`private_key_file`
-
-        write_public : bool
-            An option, ``True`` by default, for whether the public key should be written to :attr:`public_key_file`
-        """
-        # Keep track of whether we are in the process of writing public/private files.
-        # Also, adjust parameter values based on whether this is nested inside another call due to lazy loading.
-        # I.e., both the param and the corresponding instance variable will only be True for the highest applicable
-        # call/scope in the stack.
-        if self._is_writing_private_file:
-            write_private = False
-        else:
-            self._is_writing_private_file = write_private
-
-        if self._is_writing_public_file:
-            write_public = False
-        else:
-            self._is_writing_public_file = write_public
-
-        # Next, actually perform the writes, loading things as necessary via property getters
-        try:
-            self._load_key_text()
-            if write_private and not self.private_key_file.exists():
-                self.private_key_file.write_text(self._get_private_key_text())
-                self._is_deserialized = False
-            if write_public and not self.public_key_file.exists():
-                self.public_key_file.write_text(self._public_key_text)
-        finally:
-            # Finally, put back instance values to False appropriately if True and the param is True (indicating this is
-            # the highest call in the stack and should not be skipped for the public/private key file)
-            if self._is_writing_private_file and write_private:
-                self._is_writing_private_file = False
-            if self._is_writing_public_file and write_public:
-                self._is_writing_public_file = False
+    def write_key_files(self, write_private: bool = True, write_public: bool = True):
+        super().write_key_files(write_private=write_private, write_public=write_public)
+        if write_private:
+            # update generation time
+            self.generation_time = self._read_private_key_ctime(self.private_key_file)

--- a/python/lib/scheduler/dmod/test/test_JobImpl.py
+++ b/python/lib/scheduler/dmod/test/test_JobImpl.py
@@ -4,6 +4,8 @@ from ..scheduler.resources.resource_allocation import ResourceAllocation
 from dmod.communication import NWMRequest
 from uuid import UUID
 
+from typing import List
+
 
 class TestJobImpl(unittest.TestCase):
 
@@ -11,14 +13,14 @@ class TestJobImpl(unittest.TestCase):
         self._nwm_model_request = NWMRequest.factory_init_from_deserialized_json(
             {"model": {"nwm": {"version": 2.0, "output": "streamflow", "domain": "blah", "parameters": {}}},
              "session-secret": "f21f27ac3d443c0948aab924bddefc64891c455a756ca77a4d86ec2f697cd13c"})
-        self._example_jobs = []
+        self._example_jobs: List[JobImpl]= []
         self._example_jobs.append(JobImpl(4, 1000, model_request=self._nwm_model_request,
                                           allocation_paradigm='single-node'))
 
-        self._uuid_str_vals = []
+        self._uuid_str_vals: List[str] = []
         self._uuid_str_vals.append('12345678-1234-5678-1234-567812345678')
 
-        self._resource_allocations = []
+        self._resource_allocations: List[ResourceAllocation] = []
         self._resource_allocations.append(ResourceAllocation('node001', 'node001', 4, 1000))
 
     def tearDown(self) -> None:

--- a/python/lib/scheduler/dmod/test/test_JobImpl.py
+++ b/python/lib/scheduler/dmod/test/test_JobImpl.py
@@ -11,7 +11,7 @@ class TestJobImpl(unittest.TestCase):
 
     def setUp(self) -> None:
         self._nwm_model_request = NWMRequest.factory_init_from_deserialized_json(
-            {"model": {"nwm": {"version": 2.0, "output": "streamflow", "domain": "blah", "parameters": {}}},
+            {"model": {"nwm": {"version": 2.0, "output": "streamflow", "domain": "blah", "parameters": {}, "config_data_id": "42"}},
              "session-secret": "f21f27ac3d443c0948aab924bddefc64891c455a756ca77a4d86ec2f697cd13c"})
         self._example_jobs: List[JobImpl]= []
         self._example_jobs.append(JobImpl(4, 1000, model_request=self._nwm_model_request,

--- a/python/lib/scheduler/dmod/test/test_job.py
+++ b/python/lib/scheduler/dmod/test/test_job.py
@@ -2,14 +2,18 @@ import unittest
 from ..scheduler.job.job import Job, JobImpl, RequestedJob
 from dmod.core.meta_data import TimeRange
 from dmod.communication import NWMRequest, NGENRequest, SchedulerRequestMessage
+from typing import Any, List, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dmod.communication import ModelExecRequest
 
 
 class TestJob(unittest.TestCase):
 
     def setUp(self) -> None:
-        self._example_jobs = []
-        self._model_requests = []
-        self._model_requests_json = []
+        self._example_jobs: List[RequestedJob] = []
+        self._model_requests: List["ModelExecRequest"]= []
+        self._model_requests_json: Dict[str, Any] = []
 
         # Example 0 - simple JobImpl instance based on NWMRequest for model_request value
         self._model_requests_json.append({

--- a/python/lib/scheduler/dmod/test/test_resource.py
+++ b/python/lib/scheduler/dmod/test/test_resource.py
@@ -1,0 +1,124 @@
+import unittest
+from pydantic import ValidationError
+from .scheduler_test_utils import _mock_resources
+from ..scheduler.resources import Resource, ResourceAvailability
+
+
+class TestResource(unittest.TestCase):
+    def setUp(self) -> None:
+        self._resource = Resource(
+            resource_id="1",
+            hostname="somehost",
+            availability="active",
+            state="ready",
+            cpu_count=4,
+            memory=(2 ** 30) * 8,
+            total_cpu_count=8,
+            total_memory=(2 ** 30) * 16,
+        )
+
+    def test_factory_init_from_dict_coerces_fields_correctly(self):
+        for i, input in enumerate(_mock_resources):
+            with self.subTest(i=i):
+                o = Resource.factory_init_from_dict(input)
+                assert o.resource_id == input["node_id"]
+                assert o.pool_id == input["node_id"]
+                assert o.hostname == input["Hostname"]
+                assert (
+                    o.availability.name.casefold() == input["Availability"].casefold()
+                )
+                assert o.state.name.casefold() == input["State"].casefold()
+                assert o.memory == input["MemoryBytes"]
+                assert o.cpu_count == input["CPUs"]
+                assert o.total_cpus == input["CPUs"]
+                assert o.total_memory == input["MemoryBytes"]
+
+    def test_factory_init_from_dict_works_case_insensitively(self):
+        input = {
+            "NODE_ID": "Node-0003",
+            "hostname": "hostname3",
+            "AVAILABILITY": "active",
+            "state": "ready",
+            "CPUS": 42,
+            "memorybytes": 200000000000,
+        }
+        o = Resource.factory_init_from_dict(input)
+        assert o.resource_id == input["NODE_ID"]
+        assert o.pool_id == input["NODE_ID"]
+        assert o.hostname == input["hostname"]
+        assert o.availability.name.casefold() == input["AVAILABILITY"].casefold()
+        assert o.state.name.casefold() == input["state"].casefold()
+        assert o.memory == input["memorybytes"]
+        assert o.cpu_count == input["CPUS"]
+        assert o.total_cpus == input["CPUS"]
+        assert o.total_memory == input["memorybytes"]
+
+    def test_set_availability(self):
+        resource = self._resource
+        availability = ResourceAvailability.UNKNOWN
+        resource.set_availability(availability)
+        assert resource.availability == ResourceAvailability.UNKNOWN
+
+        availability = ResourceAvailability.ACTIVE
+        resource.set_availability(availability)
+        assert resource.availability == ResourceAvailability.ACTIVE
+
+        availability = ResourceAvailability.INACTIVE
+        resource.set_availability(availability)
+        assert resource.availability == ResourceAvailability.INACTIVE
+
+        resource.set_availability("unknown")
+        assert resource.availability == ResourceAvailability.UNKNOWN
+
+        resource.set_availability("active")
+        assert resource.availability == ResourceAvailability.ACTIVE
+
+        resource.set_availability("inactive")
+        assert resource.availability == ResourceAvailability.INACTIVE
+
+        # remove in future
+        with self.assertWarns(DeprecationWarning):
+            availability = ResourceAvailability.UNKNOWN
+            resource.availability = availability
+            assert resource.availability == ResourceAvailability.UNKNOWN
+
+        with self.assertWarns(DeprecationWarning):
+            availability = ResourceAvailability.ACTIVE
+            resource.availability = availability
+            assert resource.availability == ResourceAvailability.ACTIVE
+
+        with self.assertWarns(DeprecationWarning):
+            availability = ResourceAvailability.INACTIVE
+            resource.availability = availability
+            assert resource.availability == ResourceAvailability.INACTIVE
+
+    def test_eq(self):
+        resource = self._resource
+        assert resource == resource
+        assert resource == Resource.factory_init_from_dict(resource.to_dict())
+
+    def test_init_with_more_cpu_than_total_cpu(self):
+        with self.assertRaises(ValidationError):
+            Resource(
+                cpu_count=8,
+                total_cpu_count=4,
+                resource_id="1",
+                hostname="somehost",
+                availability="active",
+                state="ready",
+                memory=8,
+                total_memory=8,
+            )
+
+    def test_init_with_more_memory_than_total_memory(self):
+        with self.assertRaises(ValidationError):
+            Resource(
+                memory=8,
+                total_memory=4,
+                resource_id="1",
+                hostname="somehost",
+                availability="active",
+                state="ready",
+                cpu_count=8,
+                total_cpu_count=8,
+            )

--- a/python/lib/scheduler/dmod/test/test_rsa_key_pair.py
+++ b/python/lib/scheduler/dmod/test/test_rsa_key_pair.py
@@ -55,7 +55,7 @@ class TestRsaKeyPair(unittest.TestCase):
         # This should result in the same file names as key_pair, and so the constructor should resolve that it needs to
         # load the key, not regenerate it
         reserialized_key = RsaKeyPair(directory=key_pair.directory, name=key_pair.name)
-        self.assertEqual(key_pair.private_key, reserialized_key.private_key)
+        self.assertTrue(key_pair.private_key, reserialized_key.private_key)
 
     def test_generate_key_pair_1_e(self):
         """

--- a/python/lib/scheduler/dmod/test/test_rsa_key_pair.py
+++ b/python/lib/scheduler/dmod/test/test_rsa_key_pair.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from ..scheduler.rsa_key_pair import RsaKeyPair
 from typing import Dict
@@ -186,3 +187,31 @@ class TestRsaKeyPair(unittest.TestCase):
         key_pair = self.rsa_key_pairs[1]
         kp = RsaKeyPair(directory=key_pair.directory, name=key_pair.name)
         self.assertTrue(kp.is_deserialized)
+
+    def test_reassign_directory_to_default(self):
+        """
+        verify object `is_deserialized` property is false when key is generated.
+        """
+        key_pair = self.rsa_key_pairs[1]
+        default_location = Path.home() / ".ssh"
+        self.assertNotEqual(key_pair.directory, default_location)
+
+        key_pair.directory = None
+        self.assertEqual(key_pair.directory, default_location)
+
+    def test_reassign_directory_creates_directory_if_not_exist(self):
+        """
+        verify object `is_deserialized` property is false when key is generated.
+        """
+        key_pair = self.rsa_key_pairs[1]
+        with TemporaryDirectory() as dir:
+            dir = Path(dir)
+            new_dir = dir / ".ssh"
+
+            self.assertFalse(new_dir.exists())
+            self.assertNotEqual(key_pair.directory, new_dir)
+
+            key_pair.directory = new_dir
+
+            self.assertTrue(new_dir.exists())
+            self.assertEqual(key_pair.directory, new_dir)

--- a/python/lib/scheduler/dmod/test/test_rsa_key_pair.py
+++ b/python/lib/scheduler/dmod/test/test_rsa_key_pair.py
@@ -196,8 +196,15 @@ class TestRsaKeyPair(unittest.TestCase):
         default_location = Path.home() / ".ssh"
         self.assertNotEqual(key_pair.directory, default_location)
 
+        o_pub_key = key_pair.public_key_file
+        o_priv_key = key_pair.private_key_file
+
         key_pair.directory = None
         self.assertEqual(key_pair.directory, default_location)
+
+        # remove original public key and private key
+        o_priv_key.unlink(missing_ok=True)
+        o_pub_key.unlink(missing_ok=True)
 
     def test_reassign_directory_creates_directory_if_not_exist(self):
         """

--- a/python/lib/scheduler/dmod/test/test_rsa_key_pair.py
+++ b/python/lib/scheduler/dmod/test/test_rsa_key_pair.py
@@ -1,16 +1,22 @@
 import unittest
+from tempfile import TemporaryDirectory
 from ..scheduler.rsa_key_pair import RsaKeyPair
+from typing import Dict
 
 
 class TestRsaKeyPair(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.rsa_key_pairs = dict()
+        self.rsa_key_pairs: Dict[int, RsaKeyPair] = dict()
         self.rsa_key_pairs[1] = RsaKeyPair(directory='.', name='id_rsa_1')
 
+        self.serial_rsa_key_pairs: Dict[int, dict] = dict()
+        self.serial_rsa_key_pairs[1] = self.rsa_key_pairs[1].to_dict()
+
+
     def tearDown(self) -> None:
-        self.rsa_key_pairs[1].private_key_file.unlink()
-        self.rsa_key_pairs[1].public_key_file.unlink()
+        self.rsa_key_pairs[1].private_key_file.unlink(missing_ok=True)
+        self.rsa_key_pairs[1].public_key_file.unlink(missing_ok=True)
 
     def test_generate_key_pair_1_a(self):
         """
@@ -37,7 +43,7 @@ class TestRsaKeyPair(unittest.TestCase):
         # This should result in the same file names as key_pair, and so the constructor should resolve that it needs to
         # load the key, not regenerate it
         reserialized_key = RsaKeyPair(directory=key_pair.directory, name=key_pair.name)
-        self.assertTrue(key_pair, reserialized_key)
+        self.assertEqual(key_pair, reserialized_key)
 
     def test_generate_key_pair_1_d(self):
         """
@@ -49,7 +55,7 @@ class TestRsaKeyPair(unittest.TestCase):
         # This should result in the same file names as key_pair, and so the constructor should resolve that it needs to
         # load the key, not regenerate it
         reserialized_key = RsaKeyPair(directory=key_pair.directory, name=key_pair.name)
-        self.assertTrue(key_pair.private_key, reserialized_key.private_key)
+        self.assertEqual(key_pair.private_key, reserialized_key.private_key)
 
     def test_generate_key_pair_1_e(self):
         """
@@ -61,4 +67,122 @@ class TestRsaKeyPair(unittest.TestCase):
         # This should result in the same file names as key_pair, and so the constructor should resolve that it needs to
         # load the key, not regenerate it
         reserialized_key = RsaKeyPair(directory=key_pair.directory, name=key_pair.name)
-        self.assertTrue(key_pair.private_key_pem, reserialized_key.private_key_pem)
+        self.assertEqual(key_pair.private_key_pem, reserialized_key.private_key_pem)
+
+    def test_generate_key_pair_1_from_dict_a(self):
+        """
+        """
+        key_pair = self.rsa_key_pairs[1]
+        key_pair.write_key_files()
+        # This should result in the same file names as key_pair, and so the constructor should resolve that it needs to
+        # load the key, not regenerate it
+
+        key_pair_dict = key_pair.to_dict()
+        key_pair_from_dict = RsaKeyPair.factory_init_from_deserialized_json(key_pair_dict)
+        self.assertEqual(key_pair_from_dict, key_pair)
+
+    def test_delete_key_files(self):
+        """
+        Verify that the `delete_key_files` method deletes both public and private key _if they
+        exist_ to start with.
+        """
+        key_pair = self.rsa_key_pairs[1]
+        key_pair.delete_key_files()
+        self.assertFalse(key_pair.private_key_file.exists())
+        self.assertFalse(key_pair.public_key_file.exists())
+
+    def test_factory_init_from_deserialized_json_does_not_write_key_files_on_init(self):
+        """
+        verify key files are not created if they do not already exist on factory init.
+        """
+        key_pair = self.rsa_key_pairs[1]
+        kp_as_dict = key_pair.to_dict()
+        key_pair.delete_key_files()
+
+        kp_from_factory = RsaKeyPair.factory_init_from_deserialized_json(kp_as_dict)
+
+        assert kp_from_factory is not None
+        self.assertFalse(kp_from_factory.private_key_file.exists())
+        self.assertFalse(kp_from_factory.public_key_file.exists())
+
+    def test_factory_init_from_deserialized_json_verifies_private_key_matches_successfully(self):
+        """
+        verify key files are not created if they do not already exist on factory init.
+        """
+        key_pair = self.rsa_key_pairs[1]
+        self.assertTrue(key_pair.private_key_file.exists())
+
+        kp_as_dict = key_pair.to_dict()
+        kp_from_factory = RsaKeyPair.factory_init_from_deserialized_json(kp_as_dict)
+        assert kp_from_factory is not None
+        # this should have been called in __init__
+        kp_from_factory._delete_existing_key_files_if_priv_keys_differ() # type: ignore
+        self.assertTrue(kp_from_factory.private_key_file.exists())
+
+    def test_factory_init_from_deserialized_json_does_not_write_pub_key_file_when_priv_exists(self):
+        """
+        verify pub key file is not created by factory init if priv key file already exists.
+        are not created if they do not already exist on factory init.
+        """
+        key_pair = self.rsa_key_pairs[1]
+        self.assertTrue(key_pair.private_key_file.exists())
+        self.assertTrue(key_pair.public_key_file.exists())
+
+        key_pair.public_key_file.unlink(missing_ok=True)
+        self.assertFalse(key_pair.public_key_file.exists())
+
+        kp_as_dict = key_pair.to_dict()
+        kp_from_factory = RsaKeyPair.factory_init_from_deserialized_json(kp_as_dict)
+        assert kp_from_factory is not None
+
+        # main concern being tested
+        self.assertFalse(kp_from_factory.public_key_file.exists())
+
+        self.assertTrue(kp_from_factory.private_key_file.exists())
+
+    def test_factory_init_from_deserialized_json_is_deserialized(self):
+        """
+        verify object `is_deserialized` property is true on factory init with no key files on disk.
+        """
+        key_pair = self.rsa_key_pairs[1]
+
+        kp_as_dict = key_pair.to_dict()
+
+        # remove key files
+        key_pair.delete_key_files()
+        self.assertFalse(key_pair.private_key_file.exists())
+        self.assertFalse(key_pair.public_key_file.exists())
+
+        kp_from_factory = RsaKeyPair.factory_init_from_deserialized_json(kp_as_dict)
+        assert kp_from_factory is not None
+
+        # main concern being tested
+        self.assertTrue(kp_from_factory.is_deserialized)
+
+    def test_factory_init_from_deserialized_json_is_deserialized_with_key_files_present(self):
+        """
+        verify object `is_deserialized` property is true on factory init key files on disk.
+        """
+        key_pair = self.serial_rsa_key_pairs[1]
+
+        kp_from_factory = RsaKeyPair.factory_init_from_deserialized_json(key_pair)
+        assert kp_from_factory is not None
+
+        # main concern being tested
+        self.assertTrue(kp_from_factory.is_deserialized)
+
+    def test_is_deserialized_is_false_when_key_is_generated(self):
+        """
+        verify object `is_deserialized` property is false when key is generated.
+        """
+        with TemporaryDirectory() as dir:
+            key_pair = RsaKeyPair(directory=dir, name="test_is_deserialized")
+            self.assertFalse(key_pair.is_deserialized)
+
+    def test_is_deserialized_is_true_when_key_is_present(self):
+        """
+        verify object `is_deserialized` property is false when key is generated.
+        """
+        key_pair = self.rsa_key_pairs[1]
+        kp = RsaKeyPair(directory=key_pair.directory, name=key_pair.name)
+        self.assertTrue(kp.is_deserialized)

--- a/python/lib/scheduler/setup.py
+++ b/python/lib/scheduler/setup.py
@@ -21,7 +21,7 @@ setup(
     url='',
     license='',
     install_requires=['docker', 'Faker', 'dmod-communication>=0.8.0', 'dmod-modeldata>=0.7.1', 'dmod-redis>=0.1.0',
-                      'dmod-core>=0.2.0', 'cryptography', 'uri', 'pyyaml'],
+                      'dmod-core>=0.2.0', 'cryptography', 'uri', 'pyyaml', 'pydantic'],
     packages=find_namespace_packages(exclude=['dmod.test', 'src'])
 )
 


### PR DESCRIPTION
This PR refactors `dmod.scheduler` into compliance with ecosystem wide changes introduced in #256 to serialization and deserialization. See https://github.com/NOAA-OWP/DMOD/pull/239 for context. 

## Additions

-

## Removals

-

## Changes

- `RsaKeyPair` now eagerly generates an RSA private key if one does not exist on disk or is not provided as a field.

## Testing

1.

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
