### PR TITLE
Pydantic core refactor revisions

### DIFF
--- a/python/lib/core/dmod/core/dataset.py
+++ b/python/lib/core/dmod/core/dataset.py
@@ -80,7 +80,7 @@ class Dataset(Serializable):
     last_updated: Optional[datetime]
 
     @validator("created_on", "last_updated", "expires", pre=True)
-    def parse_dates(cls, v):
+    def _parse_dates(cls, v):
         if v is None:
             return None
 
@@ -90,18 +90,18 @@ class Dataset(Serializable):
         return datetime.strptime(v, cls.get_datetime_str_format())
 
     @validator("created_on", "last_updated", "expires")
-    def drop_microseconds(cls, v: datetime):
+    def _drop_microseconds(cls, v: datetime):
         return v.replace(microsecond=0)
 
     @validator("manager", pre=True)
-    def drop_manager_if_not_constructed_subtype(cls, value):
+    def _drop_manager_if_not_constructed_subtype(cls, value):
         # manager can only be passed as constructed DatasetManager subtype
         if isinstance(value, DatasetManager):
             return value
         return None
 
     @root_validator()
-    def set_manager_uuid(cls, values) -> dict:
+    def _set_manager_uuid(cls, values) -> dict:
         manager: Optional[DatasetManager] = values["manager"]
         # give preference to `manager.uuid` otherwise use specified `manager_uuid`
         if manager is not None:

--- a/python/lib/core/dmod/core/dataset.py
+++ b/python/lib/core/dmod/core/dataset.py
@@ -128,6 +128,12 @@ class Dataset(Serializable):
             "last_updated": _serialize_datetime
             }
 
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Dataset) and self.name == other.name and self.category == other.category \
+               and self.dataset_type == other.dataset_type and self.data_domain == other.data_domain \
+               and self.access_location == other.access_location and self.is_read_only == other.is_read_only \
+               and self.created_on == other.created_on
+
     def __hash__(self) -> int:
         return hash(','.join([self.__class__.__name__, self.name, self.category.name, str(hash(self.data_domain)),
                               self.access_location, str(self.is_read_only), str(hash(self.created_on))]))

--- a/python/lib/core/dmod/core/dataset.py
+++ b/python/lib/core/dmod/core/dataset.py
@@ -790,3 +790,7 @@ class DatasetManager(ABC):
             UUID for this instance.
         """
         return self._uuid
+
+# DatasetManager is a field type of Dataset and is defined after Dataset. As such, it necessary to
+# update forward references after DatasetManager has been defined.
+Dataset.update_forward_refs()

--- a/python/lib/core/dmod/core/dataset.py
+++ b/python/lib/core/dmod/core/dataset.py
@@ -113,13 +113,22 @@ class Dataset(Serializable):
         return values
 
     class Config:
+        def _serialize_datetime(self: "Dataset", value: datetime) -> str:
+            return value.strftime(self.get_datetime_str_format())
+
         # NOTE: re-validate when any field is re-assigned (i.e. `model.foo = 12`)
         # TODO: in future deprecate setting properties unless through a setter method
         validate_assignment = True
         arbitrary_types_allowed = True
-        field_serializers = {"uuid": lambda f: str(f)}
+        field_serializers = {
+            "uuid": lambda f: str(f),
+            "manager_uuid": lambda f: str(f),
+            "expires": _serialize_datetime,
+            "created_on": _serialize_datetime,
+            "last_updated": _serialize_datetime
+            }
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(','.join([self.__class__.__name__, self.name, self.category.name, str(hash(self.data_domain)),
                               self.access_location, str(self.is_read_only), str(hash(self.created_on))]))
 

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -3,10 +3,13 @@ from datetime import datetime
 from .enum import PydanticEnum
 from .serializable import Serializable
 from numbers import Number
-from typing import Any, Dict, List, Optional, Set, Type, Union, overload
+from typing import Any, Dict, List, Optional, Set, Type, TYPE_CHECKING, Union, overload
 from collections.abc import Iterable
 from collections import OrderedDict
-from pydantic import root_validator, validator, PyObject, Field, StrictStr, StrictFloat, StrictInt
+from pydantic import root_validator, validator, PyObject, PrivateAttr, Field, StrictStr, StrictFloat, StrictInt
+
+if TYPE_CHECKING:
+    from pydantic.typing import AbstractSetIntStr, MappingIntStrAny
 
 
 class StandardDatasetIndex(PydanticEnum):

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -358,7 +358,7 @@ class ContinuousRestriction(Serializable):
         elif self.variable != other.variable:
             return False
         else:
-           return self.begin <= other.begin and self.end >= other.end
+            return self.begin <= other.begin and self.end >= other.end
 
 
 class DiscreteRestriction(Serializable):
@@ -674,7 +674,7 @@ class DataDomain(Serializable):
             Map of the continuous restrictions defining this domain, keyed by variable name.
         """
         if self._continuous_restrictions is None:
-                self._continuous_restrictions = {k.variable: k for k in self.continuous} if self.continuous else {}
+            self._continuous_restrictions = {k.variable: k for k in self.continuous} if self.continuous else {}
         return self._continuous_restrictions
 
     @property

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from .enum import PydanticEnum
 from .serializable import Serializable
 from numbers import Number
-from typing import Any, Dict, List, Literal, Optional, Set, Type, Union
+from typing import Any, Dict, List, Optional, Set, Type, Union, overload
 from collections.abc import Iterable
 from collections import OrderedDict
 from pydantic import root_validator, validator, PyObject, Field, StrictStr, StrictFloat, StrictInt
@@ -505,6 +505,46 @@ class DataDomain(Serializable):
             msg = "Cannot create {} without at least one finite continuous or discrete restriction"
             raise RuntimeError(msg.format(cls.__name__))
         return values
+
+    @overload
+    def __init__(
+        self,
+        *,
+        data_format: DataFormat,
+        continuous: Optional[List[ContinuousRestriction]],
+        discrete: Optional[List[DiscreteRestriction]],
+        data_fields: Optional[Dict[str, Union[str, int, float, Any]]],
+        **data: Dict[str, Any]
+    ): ...
+
+    @overload
+    def __init__(
+        self,
+        data_format: DataFormat,
+        continuous_restrictions: Optional[List[ContinuousRestriction]] = None,
+        discrete_restrictions: Optional[List[DiscreteRestriction]] = None,
+        custom_data_fields: Optional[Dict[str, Type]] = None
+    ): ...
+
+    def __init__(
+        self,
+        data_format: DataFormat,
+        continuous_restrictions: Optional[List[ContinuousRestriction]] = None,
+        discrete_restrictions: Optional[List[DiscreteRestriction]] = None,
+        custom_data_fields: Optional[Dict[str, Type]] = None,
+        **data: Dict[str, Any]
+    ):
+        # assume fields provided by alias
+        if data:
+            super().__init__(data_format=data_format, **data)
+            return
+
+        super().__init__(
+            data_format=data_format,
+            continuous=continuous_restrictions,
+            discrete=discrete_restrictions,
+            custom_data_fields=custom_data_fields,
+        )
 
     @classmethod
     def factory_init_from_restriction_collections(cls, data_format: DataFormat, **kwargs) -> 'DataDomain':

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -229,7 +229,7 @@ class ContinuousRestriction(Serializable):
     subclass: PyObject
 
     @root_validator(pre=True)
-    def coerce_times_if_datetime_pattern(cls, values):
+    def _coerce_times_if_datetime_pattern(cls, values):
         subclass_str = values.get("subclass")
 
         if subclass_str is None:
@@ -254,7 +254,7 @@ class ContinuousRestriction(Serializable):
         return values
 
     @root_validator()
-    def validate_start_before_end(cls, values):
+    def _validate_start_before_end(cls, values):
         if values["begin"] > values["end"]:
             raise RuntimeError("Cannot have {} with begin value larger than end.".format(cls.__name__))
 
@@ -477,7 +477,7 @@ class DataDomain(Serializable):
         return value
 
     @validator("custom_data_fields")
-    def validate_data_fields(cls, values):
+    def _validate_data_fields(cls, values):
         def handle_type_map(t):
             if t == "str" or t == str:
                 return str
@@ -498,9 +498,9 @@ class DataDomain(Serializable):
         return {k: handle_type_map(v) for k, v in values.items()}
 
     @root_validator()
-    def validate_sufficient_restrictions(cls, values):
-        continuous_restrictions = values.get("continuous_restrictions", [])
-        discrete_restrictions = values.get("discrete_restrictions", [])
+    def _validate_sufficient_restrictions(cls, values):
+        continuous_restrictions = values.get("continuous", [])
+        discrete_restrictions = values.get("discrete", [])
         if len(continuous_restrictions) + len(discrete_restrictions) == 0:
             msg = "Cannot create {} without at least one finite continuous or discrete restriction"
             raise RuntimeError(msg.format(cls.__name__))

--- a/python/lib/core/dmod/core/serializable_dict.py
+++ b/python/lib/core/dmod/core/serializable_dict.py
@@ -1,0 +1,226 @@
+from functools import lru_cache
+from typing import (
+    Any,
+    ClassVar,
+    Dict,
+    ItemsView,
+    Iterable,
+    Iterator,
+    KeysView,
+    Tuple,
+    Type,
+    TypeVar,
+    ValuesView,
+)
+
+from dmod.core.serializable import Serializable
+from pydantic import Extra, ValidationError
+from typing_extensions import Self
+
+M = TypeVar("M", bound="SerializableDict")
+
+
+class SerializableDict(Serializable):
+    """
+    A `Serializable` subtype that implements the `dict`interface. This means you can treat
+    `SerializableDict` and it's subtypes as if they were `dict` instances. Likewise,
+    `SerializableDict` subclasses are semantically specified equivalently to `Serializable`
+    subtypes. However there are subtle divergent behavioral differences between `SerializableDict`,
+    `Serializable`, and built-in `dict`:
+
+    `SerializableDict` vs `Serializable`:
+        - `SerializableDict` subclasses allow extra, non-validated, fields. Extra fields _are_
+        included in serialized form (e.g. `to_dict()`). Toggle the `Config.extra` flag to change
+        this behavior.
+
+    `SerializableDict` vs `dict`:
+        - `clear()` removes all extra fields; non-extra fields are untouched. As a result, `len()`
+        after a `clear()` will not be 0 if the `SerializableDict` has non-fields.
+
+        - Deleting non-extra fields is a `KeyError`. `del` and `pop()` will always raise
+        `KeyError`'s if a non-extra field name is provided. Likewise, `popitem()` can also raise a
+        `KeyError` if the last item inserted into `__dict__` was a non-extra field or if `__dict__`
+        is empty.
+
+        - If `Config.validate_assignment` is **on**, non-extra fields are validated. As a results,
+        setting via `[]` (`__setitem__`) or `setdefault()` could raise a `pydantic.ValidationError`
+        if validation fails.
+
+        - If `Config.validate_assignment` is **on**, `update()` can raise a
+        `pydantic.ValidationError`. However, `update()` _guarantees_ if a `pydantic.ValidationError`
+        is thrown, `__dict__` will _not_ be left in a partially updated state. Meaning, the
+        pre-`update()` state of `__dict__` will be restored. A performance penalty is taken to
+        guarantee this. A deep copy of `__dict__` is taken for roll-back purposes. The
+        `update_unsafe()` method is provided if you need to avoid this performance penalty. Note,
+        `update_unsafe()` operates the same as `update()` when `Config.validate_assignment` if off.
+    """
+
+    __SENTINEL: ClassVar[object] = object()
+
+    class Config:
+        extra = Extra.allow
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.__dict__
+
+    def __delitem__(self, key: str):
+        if key in self.__fields__:
+            raise KeyError("Deleting non-extra fields is forbidden.")
+
+        del self.__dict__[key]
+
+    def __getitem__(self, key: str) -> Any:
+        return self.__dict__[key]
+
+    def __len__(self) -> int:
+        return len(self.__dict__)
+
+    def __setitem__(self, key: str, value: Any):
+        if key in self.__fields__:
+            # validation is performed if `Config.validate_assignment` flag on
+            setattr(self, key, value)
+            return
+
+        self.__dict__[key] = value
+
+    def __iter__(self) -> Iterator[str]:
+        return self.__dict__.__iter__()
+
+    def clear(self):
+        """Remove all non-extra fields"""
+        keys_to_remove = set(self.__dict__).difference(self.__fields__)
+        for key in keys_to_remove:
+            del self.__dict__[key]
+
+    @classmethod
+    def fromkeys(cls, iterable: Iterable[Any], value: Any = None) -> Self:
+        return cls(**{k: value for k in iterable})
+
+    def get(self, key: str, default: Any = None) -> Any:
+        if key not in self:
+            return default
+        return self[key]
+
+    def items(self) -> ItemsView[str, Any]:
+        return self.__dict__.items()
+
+    def keys(self) -> KeysView[str]:
+        return self.__dict__.keys()
+
+    def pop(self, key: str, default: Any = __SENTINEL) -> Any:
+        if key in self.__fields__:
+            raise KeyError("Deleting non-extra fields is forbidden.")
+
+        if default == self.__SENTINEL:
+            return self.__dict__.pop(key)
+
+        return self.__dict__.pop(key, default)
+
+    def popitem(self) -> Tuple[str, Any]:
+        key, value = self.__dict__.popitem()
+
+        if key in self.__fields__:
+            self[key] = value
+            raise KeyError("Deleting non-extra fields is forbidden.")
+
+        return key, value
+
+    def setdefault(self, key: str, default: Any = None):
+        try:
+            return self[key]
+        except KeyError:
+            self[key] = default
+
+        return default
+
+    def update(self, values: Dict[str, Any]):
+        """
+        Update the dictionary with the key/value pairs from `values`, overwriting existing keys.
+
+        Note, if `Config.validate_assignment` is **on**, `update()` can raise a
+        `pydantic.ValidationError`. However, `update()` _guarantees_ if a `pydantic.ValidationError`
+        is thrown, `__dict__` will _not_ be left in a partially updated state. Meaning, the
+        pre-`update()` state of `__dict__` will be restored. A performance penalty is taken to
+        guarantee this. A deep copy of `__dict__` is taken for roll-back purposes. The
+        `update_unsafe()` method is provided if you need to avoid this performance penalty. Note,
+        `update_unsafe()` operates the same as `update()` when `Config.validate_assignment` if off.
+
+        Parameters
+        ----------
+        values : Dict[str, Any]
+
+        Raises
+        ------
+        ValidationError
+            This can only be raised if `Config.validate_assignment` is on.
+        """
+        validate_assignment = _validate_assignment(type(self))
+        # field validation is off. fast branch.
+        if not validate_assignment:
+            self.update_unsafe(values)
+            return
+
+        # field validation is on. It is possible while updating fields that validation fails and
+        # `__dict__` is left in a partially updated state. For this reason, `__dict__` must be
+        # deep copied.  Then try and update with `values`, if there are exceptions, `__dict__` is
+        # replaced with the copy.
+        import copy
+
+        original_state = copy.deepcopy(self.__dict__)
+
+        try:
+            for key, value in values.items():
+                self[key] = value
+        except ValidationError as e:
+            # `pydantic.BaseModel.__setattr__` overload embeds __dict__ within __dict__ if set
+            # through it's `__setattr__`. use object's __setattr__ to get around this.
+            object.__setattr__(self, "__dict__", original_state)
+            raise e
+
+    def update_unsafe(self, values: Dict[str, Any]):
+        """
+        Update the dictionary with the key/value pairs from `values`, overwriting existing keys even
+        if `Config.validate_assignment` is on. Field validation will not be performed even if
+        `Config.validate_assignment` flag is on. Use `update()` if `Config.validate_assignment` is
+        **off** -- there is no benefit to using this method.
+
+        Parameters
+        ----------
+        values : Dict[str, Any]
+        """
+        self.__dict__.update(values)
+
+    def values(self) -> ValuesView[Any]:
+        return self.__dict__.values()
+
+
+@lru_cache(maxsize=None)
+def _validate_assignment(cls: Type[M]) -> bool:
+    validate_assignment: bool = False
+
+    # base case
+    if cls == Serializable:
+        return validate_assignment
+
+    super_classes = cls.__mro__
+    base_class_index = super_classes.index(Serializable)
+
+    # index 0 is the calling cls.
+    # walk to mro in reverse order from superclasses up until cls (stopping condition).
+    #
+    # _toggle_ `validate_assignment` flag if set in superclasses.
+    for s in super_classes[1:base_class_index][::-1]:
+        if not issubclass(s, Serializable):
+            continue
+
+        # doesn't have a Config class or Config.validate_assignment
+        if not hasattr(s, "Config") and not hasattr(s.Config, "validate_assignment"):
+            continue
+
+        validate_assignment = _validate_assignment(s)
+
+    # has Config class and Config.validate_assignment
+    if hasattr(cls, "Config") and hasattr(cls.Config, "validate_assignment"):
+        validate_assignment = cls.Config.validate_assignment
+
+    return validate_assignment

--- a/python/lib/core/dmod/test/test_dataset.py
+++ b/python/lib/core/dmod/test/test_dataset.py
@@ -67,7 +67,7 @@ class TestDataset(unittest.TestCase):
                                       "uuid": str(self.example_datasets[i].uuid),
                                       "access_location": 'location_{}'.format(i),
                                       "is_read_only": False,
-                                      "created_on": self._created_on, # NOTE: breaking change
+                                      "created_on": self._created_on.strftime(date_fmt),
                                       })
 
     def test_factory_init_from_deserialized_json_0_a(self):

--- a/python/lib/core/dmod/test/test_meta_data.py
+++ b/python/lib/core/dmod/test/test_meta_data.py
@@ -157,7 +157,7 @@ class TestDataDomain(unittest.TestCase):
         o = DataDomain(
             data_format=DataFormat.AORC_CSV,
             discrete_restrictions=[disc_rest],
-            data_fields=dict(a="str", b="float", c="int", d="datetime"),
+            custom_data_fields=dict(a="str", b="float", c="int", d="datetime"),
         )
         self.assertEqual(o.custom_data_fields["a"], str)
         self.assertEqual(o.custom_data_fields["b"], float)
@@ -207,7 +207,7 @@ class TestDataDomain(unittest.TestCase):
     def test_factory_init_from_restriction_collections(self):
         catchment_id = ["12"]
         o = DataDomain.factory_init_from_restriction_collections(data_format=DataFormat.AORC_CSV, CATCHMENT_ID=catchment_id)
-        self.assertListEqual(o.discrete_restrictions[0].values, catchment_id)
+        self.assertListEqual(o.discrete_restrictions[StandardDatasetIndex.CATCHMENT_ID].values, catchment_id)
 
     def test_factory_init_from_restriction_collections_fail_for_mismatching_index_field(self):
         with self.assertRaises(RuntimeError):


### PR DESCRIPTION
Several fixes and improvements to `dmod.core` post #256. Most notably this includes fixes to `DataDomain` `continuous` and `discrete` restriction fields behavior. These fields now de/serialized as lists and are exposed on `DataDomain` instances as dictionaries. This _now_ matching the pre-pydantic port behavior.

A `SerializableDict` class is also added. This enables treating a `Serializable` as if it were a dictionary with partial field validation.

## Additions

- `dmod.core.serializable.SerializableDict` a `Serializable` subtype that implements python's `dict` interface. 

## TODO

- [ ] I have a local unittests for `SerializableDict` that I need to port from `pydantic` to `python.UnitTest`.

## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: