### PR TITLE
Monitor service test fix

### DIFF
--- a/python/services/monitorservice/dmod/test/test_monitor_service.py
+++ b/python/services/monitorservice/dmod/test/test_monitor_service.py
@@ -5,6 +5,7 @@ from dmod.core.execution import AllocationParadigm
 from ..monitorservice.service import Monitor, MonitorService, Job, JobStatus, MetadataMessage, MetadataPurpose,\
     MonitoredChange, MetadataResponse
 from dmod.scheduler.job import JobExecPhase, JobImpl, JobExecStep
+from dmod.communication import NWMRequest
 
 
 class MockMonitor(Monitor):
@@ -84,9 +85,14 @@ class TestMonitorService(unittest.TestCase):
         # First one has no actual monitor
         self._services.append(MockMonitorService(MockMonitor()))
 
+        nwm_model_request = NWMRequest(
+            config_data_id="42",
+            session_secret="0000000000000000000000000000000000000000000000000000000000000000",
+        )
+
         self._jobs = []
         for i in range(3):
-            self._jobs.append(JobImpl(cpu_count=4, memory_size=1000, model_request=None,
+            self._jobs.append(JobImpl(cpu_count=4, memory_size=1000, model_request=nwm_model_request,
                                       allocation_paradigm=AllocationParadigm.SINGLE_NODE))
 
         self._second_meta_ex_job_id = '52204a2f-8924-48b4-abab-d289ac5aedf7'


### PR DESCRIPTION
`dmod.scheduler.job.JobImpl` requires `model_request` field be non-`None`.