### PR TITLE
Change routing build to t-route master branch

### DIFF
--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -495,7 +495,6 @@ COPY --chown=${USER} --from=rocky_build_troute ${WORKDIR}/t-route/requirements.t
 ENV BOOST_ROOT=${WORKDIR}/boost
 
 USER root
-# Note that while nothing is installed in /usr/local/lib/python3, pip apparently checks here to see if it has permissions before installing in the global site.
 RUN if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
         chgrp -R ${USER} /usr/local/lib*/python3.* \
         && chmod -R g+sw /usr/local/lib*/python3.* ; \

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -141,9 +141,15 @@ FROM rockylinux:8.5 AS download_boost
 # Redeclaring inside this stage to get default from before first FROM
 ARG BOOST_VERSION
 
-RUN curl -L -o boost_${BOOST_VERSION//./_}.tar.bz2 https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//./_}.tar.bz2/download \
-    && mkdir /boost \
-    && mv boost_${BOOST_VERSION//./_}.tar.bz2 /boost/.
+# Copy of entrypoint.sh here is just to avoid failure if there is no boost_*.tar.* present,,,
+COPY entrypoint.sh boost_*.tar.* ${WORKDIR}
+
+RUN mkdir ${WORKDIR}/boost \
+    && if compgen -G "./boost_*.tar.*" > /dev/null; then \
+        mv ${WORKDIR}/boost_*.tar.* ${WORKDIR}/boost/boost_tarball.blob ; \
+    else \
+        curl -L -o ${WORKDIR}/boost/boost_tarball.blob https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//./_}.tar.bz2/download ; \
+    fi 
 
 ################################################################################################################
 ################################################################################################################
@@ -355,8 +361,8 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && echo "alias python='python3'" >> /etc/profile \
     # Also set up boost here, since we copied the download but only just installed bzip2 to work with it \
     && cd ${BOOST_ROOT} \
-    && tar -xjf boost_${BOOST_VERSION//./_}.tar.bz2 \
-    && rm boost_${BOOST_VERSION//./_}.tar.bz2 \
+    && tar -xf boost_tarball.blob \
+    && rm boost_tarball.blob \
     && rm -rf /tmp/ngen-deps
 
 ENV PATH=${PATH}:/usr/lib64/mpich/bin

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -496,6 +496,14 @@ COPY --chown=${USER} --from=rocky_build_troute ${WORKDIR}/t-route/wheels /tmp/t-
 COPY --chown=${USER} --from=rocky_build_troute ${WORKDIR}/t-route/requirements.txt /tmp/t-route-requirements.txt
 ENV BOOST_ROOT=${WORKDIR}/boost
 
+USER root
+# Note that while nothing is installed in /usr/local/lib/python3, pip apparently checks here to see if it has permissions before installing in the global site.
+RUN if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
+        chgrp -R ${USER} /usr/local/lib*/python3.* \
+        && chmod -R g+sw /usr/local/lib*/python3.* ; \
+    fi
+USER ${USER}
+
 RUN cd ${WORKDIR}/ngen \
     && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
         pip3 install -r extern/test_bmi_py/requirements.txt; \

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -25,7 +25,7 @@ ARG COMMIT
 ARG WORKDIR=/ngen
 
 ARG TROUTE_REPO_URL=https://github.com/NOAA-OWP/t-route.git
-ARG TROUTE_BRANCH=ngen
+ARG TROUTE_BRANCH=master
 ARG TROUTE_COMMIT
 
 #### Default arguments for required dependencies needed during various build stages
@@ -259,7 +259,7 @@ ARG ROCKY_NGEN_DEPS_REQUIRED
 USER root
 RUN dnf update -y && dnf install -y ${ROCKY_NGEN_DEPS_REQUIRED} \
     && pip3 install --upgrade pip \
-    && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then pip3 install numpy; fi
+    && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then pip3 install numpy; fi 
 USER ${USER}
 
 ################################################################################################################
@@ -443,21 +443,18 @@ USER ${USER}
 RUN cd ${WORKDIR}/t-route \
     && mkdir wheels \
     && pip3 install -r ./requirements.txt \
-    && pip3 install wheel deprecated dask \
+    && pip3 install wheel deprecated dask pyarrow geopandas \
     && cd ${WORKDIR}/t-route \
-    && cd ./src/python_routing_v02 \
     && ./compiler.sh \
+    && cd ./src/troute-network \
     && python3 setup.py bdist_wheel \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
-    && cd ../python_framework_v02 \
+    && cd ../troute-routing \
     && python3 setup.py bdist_wheel \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
-    && cd ../nwm_routing \
+    && cd ../troute-nwm \
     && python3 setup.py bdist_wheel \
-    && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
-    && cd ../ngen_routing \
-    && python3 setup.py bdist_wheel \
-    && cp dist/*.whl ${WORKDIR}/t-route/wheels/
+    && cp dist/*.whl ${WORKDIR}/t-route/wheels/ 
 
 USER root
 RUN rm /usr/bin/python

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -339,7 +339,7 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && cd netcdf-fortran \
     && export NCDIR=/usr NFDIR=/usr \
     && LD_LIBRARY_PATH=/usr/lib CPPFLAGS=-I/usr/include LDFLAGS=-L/usr/lib ./configure --prefix=/usr \
-    && make -j $(nproc) && make install \
+    && make -j ${BUILD_PARALLEL_JOBS} && make install \
     ##### Build and install NetCDF C++ \
     && cd /tmp/ngen-deps \
     && mkdir netcdf-cxx4 \
@@ -353,7 +353,7 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && make install \
     # Install required python dependency packages with Pip \
     && pip3 install numpy pandas pyyaml bmipy Cython blosc2 netCDF4 wheel packaging \
-    && HDF5_DIR=/usr pip3 install --install-option="\'--hdf5 \${HDF5_DIR}\'" --install-option="\'--jobs=$(nproc) \'"  --no-build-isolation tables \
+    && HDF5_DIR=/usr pip3 install --install-option="\'--hdf5 \${HDF5_DIR}\'" --install-option="\'--jobs=${BUILD_PARALLEL_JOBS} \'"  --no-build-isolation tables \
     # Make aliases for convenience \
     && alias pip='pip3' \
     && echo "alias pip='pip3'" >> /etc/profile \

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -316,20 +316,20 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && tar xfz mpich-${MPICH_VERSION}.tar.gz  \
     && cd mpich-${MPICH_VERSION} \
     && ./configure ${MPICH_CONFIGURE_OPTIONS} \
-    && make -j $(nproc) ${MPICH_MAKE_OPTIONS} && make install \
+    && make -j ${BUILD_PARALLEL_JOBS} ${MPICH_MAKE_OPTIONS} && make install \
     ##### Build and install HDF5 \
     && cd /tmp/ngen-deps \
     && tar -xzf hdf5-${HD5_VERSION}.tar.gz \
     && cd hdf5-${HD5_VERSION} \
     && ./configure --enable-parallel --prefix=/usr \
-    && make -j $(nproc) && make install \
+    && make -j ${BUILD_PARALLEL_JOBS} && make install \
     ##### Build and install NetCDF C \
     && cd /tmp/ngen-deps \
     && mkdir netcdf \
     && tar -xzf netcdf-${NETCDF_C_VERSION}.tar.gz -C netcdf --strip 1 \
     && cd netcdf \
     && LIBS=curl && ./configure --prefix=/usr \
-    && make -j $(nproc) && make install \
+    && make -j ${BUILD_PARALLEL_JOBS} && make install \
     # TODO: if we run into any problem, might need to reactivate this \
     #&& make check \
     ##### Build and install NetCDF Fortran \
@@ -347,7 +347,7 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && mkdir netcdf-cxx4/build \
     && cd netcdf-cxx4/build \
     && cmake .. \
-    && make \
+    && make -j ${BUILD_PARALLEL_JOBS} \
     # TODO: if we run into any problem, might need to reactivate this \
     # && ctest \
     && make install \

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -496,8 +496,12 @@ ENV BOOST_ROOT=${WORKDIR}/boost
 
 USER root
 RUN if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
-        chgrp -R ${USER} /usr/local/lib*/python3.* \
-        && chmod -R g+sw /usr/local/lib*/python3.* ; \
+        chgrp -R ${USER} /usr/local/lib*/python3.* ; \
+        chmod -R g+sw /usr/local/lib*/python3.* ; \
+    fi \
+    && if [ "${NGEN_ROUTING_ACTIVE}" == "ON" ]; then \
+        # These packages install command line tools, which try to go in /usr/local/bin \
+        pip3 install pyarrow pyproj fiona; \
     fi
 USER ${USER}
 
@@ -505,7 +509,9 @@ RUN cd ${WORKDIR}/ngen \
     && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
         pip3 install -r extern/test_bmi_py/requirements.txt; \
         if [ "${NGEN_ROUTING_ACTIVE}" == "ON" ] ; then \
-            pip3 install /tmp/t-route-wheels/*.whl; pip3 install -r /tmp/t-route-requirements.txt; \
+            pip3 install /tmp/t-route-wheels/*.whl; \
+            pip3 install -r /tmp/t-route-requirements.txt; \
+            pip3 install deprecated geopandas ; \
             fi; \
         fi \
     &&  if [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ]; then \

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -258,7 +258,7 @@ ARG ROCKY_NGEN_DEPS_REQUIRED
 # Note that this includes numpy, which is needed for Python BMI support, regardless of BMI module 
 USER root
 RUN dnf update -y && dnf install -y ${ROCKY_NGEN_DEPS_REQUIRED} \
-    && pip3 install --upgrade pip \
+    && pip3 install "pip>=23.0,<23.1" wheel packaging \
     && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then pip3 install numpy; fi 
 USER ${USER}
 
@@ -444,13 +444,14 @@ RUN cd ${WORKDIR}/t-route \
     && mkdir wheels \
     && pip3 install -r ./requirements.txt \
     && pip3 install wheel deprecated dask pyarrow geopandas \
+    && export FC=gfortran \
     && cd ${WORKDIR}/t-route \
     && ./compiler.sh \
     && cd ./src/troute-network \
-    && python3 setup.py bdist_wheel \
+    && python3 setup.py --use-cython bdist_wheel \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
     && cd ../troute-routing \
-    && python3 setup.py bdist_wheel \
+    && python3 setup.py --use-cython bdist_wheel \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
     && cd ../troute-nwm \
     && python3 setup.py bdist_wheel \


### PR DESCRIPTION
Switch to building/installing t-route master instead of t-route ngen branch.

## Additions

- Several small build system improvements, including using `${BUILD_PARALLEL_JOBS}` instead of `$(nproc)`, and a way to optionally pass a pre-downloaded boost tarball to the image creation process.

## Removals

- Does not work out of the box to use legacy t-route (e.g. ngen branch), which might limit capability with some older hydrofabric datasets.

## Changes

- Now compiles and builds master t-route by default (instead of ngen branch)
- Several Python elements are now installed in the global (root) site. This enables use-cases where a user other than mpi(1000) is used, e.g. using `docker run --user=$(uid -u)`, so now the routing modules are available to that user (tested!).

## Testing

1. Built and ran the `gauge_01073000` dataset, including using `--user` to change the uid

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [X] PR has an informative and human-readable title
- [X] Changes are limited to a single goal (no scope creep)
- [X] Code can be automatically merged (no conflicts)
- [X] Code follows project standards (link if applicable)
- [X] Passes all existing automated tests
- [X] Any _change_ in functionality is tested
- [X] New functions are documented (with a description, list of inputs, and expected output)
- [X] Placeholder code is flagged / future todos are captured in comments
- [X] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [X] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [X] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [X] Linux

