### PR TITLE
Address issues with Geopackage hydrofabric unique id tests

### DIFF
--- a/python/lib/modeldata/dmod/modeldata/hydrofabric/geopackage_hydrofabric.py
+++ b/python/lib/modeldata/dmod/modeldata/hydrofabric/geopackage_hydrofabric.py
@@ -1,7 +1,7 @@
 import fiona
 import geopandas as gpd
 import hashlib
-from pandas.util import hash_array
+from pandas.util import hash_pandas_object
 import numpy as np
 from pathlib import Path
 from typing import Callable, Dict, FrozenSet, Iterable, List, Optional, Tuple, Union
@@ -546,7 +546,7 @@ class GeoPackageHydrofabric(Hydrofabric):
         int
             A unique id for this instance.
         """
-        layer_hashes = [np.apply_along_axis(hash_array, 0, self._dataframes[l].values).sum() for l in self._layer_names]
+        layer_hashes = [hash_pandas_object(self._dataframes[layer]).values.sum() for layer in self._layer_names]
         return hashlib.sha1(','.join([str(h) for h in layer_hashes]).encode('UTF-8')).hexdigest()
 
     @property

--- a/python/lib/modeldata/dmod/test/test_geopackage_hydrofabric.py
+++ b/python/lib/modeldata/dmod/test/test_geopackage_hydrofabric.py
@@ -18,7 +18,7 @@ class TestGeoPackageHydrofabric(AbstractGeoPackageHydrofabricTester):
 
         # Example 1: extended hydrofabric testing attributes for hydrofabric for v1.2 VPU 1
         ex_idx = 1
-        self.hydrofabric_uids[ex_idx] = '8a24b5eeae2596ceaf21058c49a27c8ae6f444ab'
+        self.hydrofabric_uids[ex_idx] = 'b7367023aadad961315dd05e184359dad68613c3'
         self.cat_id_sets[ex_idx] = {'cat-5', 'cat-6', 'cat-7', 'cat-8', 'cat-9', 'cat-10', 'cat-11'}
         self.nexus_id_sets[ex_idx] = {'nex-7', 'nex-8', 'nex-9', 'nex-10', 'nex-11', 'nex-12', 'tnx-1000000001'}
         self.subset_id_sets[ex_idx] = {'cat-7', 'cat-8', 'cat-9', 'nex-7', 'nex-8', 'nex-9', 'nex-10'}


### PR DESCRIPTION
Changes implementation for generating unique id within _GeoPackageHydrofabric_ class to be more resilient to changes, the lack of which contributed to #324.  Also modified associated unit test to account for differences. 