### PR TITLE
Data Service Rest Refactor -- Library Code

### DIFF
--- a/python/services/dataservice/dmod/dataservice/dataset.py
+++ b/python/services/dataservice/dmod/dataservice/dataset.py
@@ -1,0 +1,138 @@
+import re
+from pydantic import BaseModel, Field, UUID4, validator
+from datetime import datetime
+from uuid import uuid4
+from typing import Annotated, ClassVar, Optional, List, Union
+from enum import Enum
+
+from .models import DataCategory, DataDomain
+
+
+class DatasetType(Enum):
+    UNKNOWN = "UNKNOWN"
+    OBJECT_STORE = "OBJECT_STORE"
+    FILESYSTEM = "FILESYSTEM"
+
+
+class Dataset(BaseModel):
+    """
+    Rrepresentation of the descriptive metadata for a grouped collection of data.
+    """
+
+    _SERIAL_DATETIME_STR_FORMAT: ClassVar = "%Y-%m-%d %H:%M:%S"
+    _NAME_RE: ClassVar = re.compile(
+        "(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$"
+    )
+
+    name: Annotated[
+        str,
+        Field(
+            description=(
+                "The name for this dataset, which also should be a unique identifier.\n"
+                "Max size is 63 characters. See https://min.io/docs/minio/container/operations/checklists/thresholds.html#id1 for details"
+            ),
+            min_length=3,
+            max_length=63,
+        ),
+    ]
+    category: Annotated[
+        DataCategory,
+        Field(
+            alias="data_category",
+            description="The ::class:`DataCategory` type value for this instance.",
+        ),
+    ]
+    data_domain: DataDomain
+    dataset_type: Annotated[DatasetType, Field(alias="type")] = DatasetType.OBJECT_STORE
+    access_location: Annotated[
+        str,
+        Field(
+            description="String representation of the location at which this dataset is accessible."
+        ),
+    ]
+    uuid: UUID4 = Field(default_factory=uuid4)
+    manager_uuid: Optional[UUID4] = None
+    is_read_only: Annotated[
+        bool, Field(description="Whether this is a dataset that can only be read from.")
+    ] = True
+    description: Optional[str] = None
+    expires: Annotated[
+        Optional[datetime],
+        Field(
+            description='The time after which a dataset may "expire" and be removed, or ``None`` if the dataset is not temporary.',
+        ),
+    ] = None
+    derived_from: Annotated[
+        Optional[str],
+        Field(
+            description="The name of the dataset from which this dataset was derived, if it is known to have been derived.",
+        ),
+    ] = None
+    derivations: Optional[List[str]] = Field(
+        default_factory=list,
+        description="""List of names of datasets which were derived from this dataset.\n
+    Note that it is not guaranteed that any such dataset still exist and/or are still available.""",
+    )
+    created_on: Annotated[
+        datetime,
+        Field(
+            description="When this dataset was created, or ``None`` if that is not known.",
+            alias="create_on",
+        ),
+    ]
+    last_updated: datetime
+
+    @validator("name")
+    def _validate_name(cls, value: str) -> str:
+        """
+        source: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+
+        The following rules apply for naming buckets in Amazon S3:
+            _ Bucket names must be between 3 (min) and 63 (max) characters long.
+            _ Bucket names can consist only of lowercase letters, numbers, dots (.), and hyphens (-).
+            _ Bucket names must begin and end with a letter or number.
+            _ Bucket names must not contain two adjacent periods.
+            _ Bucket names must not be formatted as an IP address (for example, 192.168.5.4).
+            - Bucket names must not start with the prefix xn--.
+            - Bucket names must not end with the suffix -s3alias. This suffix is reserved for access
+            point alias names. For more information, see Using a bucket-style alias for your S3
+            bucket access point.
+            - Bucket names must not end with the suffix --ol-s3. This suffix is reserved for Object
+            Lambda Access Point alias names. For more information, see How to use a bucket-style
+            alias for your S3 bucket Object Lambda Access Point.
+            - Bucket names must be unique across all AWS accounts in all the AWS Regions within a
+            partition. A partition is a grouping of Regions. AWS currently has three partitions: aws
+            (Standard Regions), aws-cn (China Regions), and aws-us-gov (AWS GovCloud (US)).
+            - A bucket name cannot be used by another AWS account in the same partition until the
+            bucket is deleted.
+            - Buckets used with Amazon S3 Transfer Acceleration can't have dots (.) in their names.
+            For more information about Transfer Acceleration, see Configuring fast, secure file
+            transfers using Amazon S3 Transfer Acceleration.
+        """
+        if cls._NAME_RE.fullmatch(value) is None:
+            raise ValueError(
+                "Invalid name. See https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html for naming rules."
+            )
+        return value
+
+    @validator("created_on", "last_updated", "expires", pre=True)
+    def _coerce_datetime(cls, value: Union[None, datetime, str]) -> Optional[datetime]:
+        if value is None:
+            return value
+
+        if isinstance(value, datetime):
+            return value
+
+        return datetime.strptime(value, cls._SERIAL_DATETIME_STR_FORMAT)
+
+    @validator("created_on", "last_updated", "expires")
+    def _drop_microseconds(cls, value: Optional[datetime]) -> Optional[datetime]:
+        if value is None:
+            return value
+        return value.replace(microsecond=0)
+
+    class Config(BaseModel.Config):
+        allow_population_by_field_name = True
+        json_encoders = {
+            datetime: lambda d: d.strftime(Dataset._SERIAL_DATETIME_STR_FORMAT)
+        }

--- a/python/services/dataservice/dmod/dataservice/dataset.py
+++ b/python/services/dataservice/dmod/dataservice/dataset.py
@@ -2,7 +2,8 @@ import re
 from pydantic import BaseModel, Field, UUID4, validator
 from datetime import datetime
 from uuid import uuid4
-from typing import Annotated, ClassVar, Optional, List, Union
+from typing import ClassVar, Optional, List, Union
+from typing_extensions import Annotated
 from enum import Enum
 
 from .models import DataCategory, DataDomain

--- a/python/services/dataservice/dmod/dataservice/dataset_client.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_client.py
@@ -1,7 +1,7 @@
 import io
 from minio import Minio
 from minio.deleteobjects import DeleteObject, DeleteError
-from typing import cast, Union, Iterable, Iterator, List
+from typing import cast, Union, Optional, Iterable, Iterator, List
 from dataclasses import dataclass
 from datetime import datetime
 from exceptiongroup import ExceptionGroup
@@ -80,7 +80,7 @@ class DatasetClient:
         name: str,
         category: DataCategory,
         domain: DataDomain,
-        *objects: ObjectToAdd,
+        objects: Optional[Iterable[ObjectToAdd]] = None,
         read_only: bool = False,
     ) -> Result[Dataset, Union[Exception, ExceptionGroup[Exception]]]:
         # NOTE: if minio-py changes their internal api this could fail in the future.

--- a/python/services/dataservice/dmod/dataservice/dataset_client.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_client.py
@@ -87,6 +87,61 @@ class DatasetClient:
         objects: Optional[Iterable[ObjectToAdd]] = None,
         read_only: bool = False,
     ) -> Result[Dataset, Union[Exception, ExceptionGroup[Exception]]]:
+        """
+        Create a new dataset. Fails if dataset already exists.
+
+        Dataset names are restricted to the following rules:
+
+            - Must be between 3 (min) and 63 (max) characters long.
+            - Can consist only of lowercase letters, numbers, dots (.), and hyphens (-).
+            - Must begin and end with a letter or number.
+            - Must not contain two adjacent periods.
+            - Must not be formatted as an IP address (for example, 192.168.5.4).
+            - Must not start with the prefix xn--.
+            - Must not end with the suffix -s3alias. This suffix is reserved for access point alias
+                names. For more information, see Using a bucket-style alias for your S3 bucket
+                access point.
+            - Must not end with the suffix --ol-s3. This suffix is reserved for Object Lambda Access
+                Point alias names. For more information, see How to use a bucket-style alias for
+                your S3 bucket Object Lambda Access Point.
+
+            see s3 bucket naming rules for more information: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+
+        Example:
+        ```python
+        from dmod.core.meta_data import (
+            DataCategory,
+            DataDomain,
+            DataFormat,
+            DiscreteRestriction,
+            StandardDatasetIndex,
+        )
+        from dmod.dataservice.dataset_client import DatasetClient
+        from minio import Minio
+
+        minio_client = Minio("127.0.0.1:9000", access_key="minioadmin", secret_key="minioadmin", secure=False)
+        client = DatasetClient(minio_client)
+
+        result = client.create(
+            "example-dataset",
+            category=DataCategory.CONFIG,
+            domain=DataDomain(
+                data_format=DataFormat.BMI_CONFIG,
+                discrete=[
+                    DiscreteRestriction(
+                        variable=StandardDatasetIndex.GLOBAL_CHECKSUM, values=["42"]
+                    )
+                ],
+            ),
+        )
+        if result.is_err():
+            # handle error
+            raise result.value
+
+        dataset = result.value
+        ```
+        """
+
         # NOTE: if minio-py changes their internal api this could fail in the future.
         # if that happens, we want this to raise.
         access_location = self._access_location(name)
@@ -148,6 +203,36 @@ class DatasetClient:
         content_type: str = "application/octet-stream",
         extract: bool = False,
     ) -> None:
+        """
+        Add object to existing dataset. Existing objects will be overwritten.
+
+        The object to upload is provided to the `reader` parameter and must provide a `read()`
+        method. Specifically: `read(self, size: Union[int, None] = ...) -> bytes`.
+
+        tar and tar.gz archives will be extracted by the data store post upload if `extract` flag is
+        set and content-type is `application/x-gzip` or `application/x-tar`. This is useful when
+        uploading large files.
+
+        Example:
+        ```python
+        import io
+        from dmod.dataservice.dataset_client import DatasetClient
+        from minio import Minio
+
+        minio_client = Minio("127.0.0.1:9000", access_key="minioadmin", secret_key="minioadmin", secure=False)
+        client = DatasetClient(minio_client)
+
+        result = client.add_object(
+            name="example-dataset",
+            object_name="test_data.txt",
+            reader=io.BytesIO(b"just some test data"),
+            content_type="text/plain",
+            size=len(b"just some test data"),
+        )
+        if result.is_err():
+            raise result.value
+        ```
+        """
         # source: https://docs.aws.amazon.com/snowball/latest/developer-guide/batching-small-files.html
         # > The auto-extract feature supports the TAR, and tar.gz formats.
         content_type = (
@@ -193,6 +278,39 @@ class DatasetClient:
     def add_objects(
         self, name: str, *objects: ObjectToAdd
     ) -> Result[None, ExceptionGroup[Exception]]:
+        """
+        Add multiple objects to an existing dataset. All objects will attempt to be uploaded, meaning
+        it is possible for the first object to fail and the last to succeed.
+
+        Example:
+        ```python
+        import io
+        from dmod.dataservice.dataset_client import DatasetClient
+        from minio import Minio
+
+        minio_client = Minio("127.0.0.1:9000", access_key="minioadmin", secret_key="minioadmin", secure=False)
+        client = DatasetClient(minio_client)
+
+        objects = [
+            ObjectToAdd(
+                "test_data.txt",
+                content_type="text/plain",
+                reader=io.BytesIO(b"just some test data"),
+                size=len(b"just some test data"),
+            ),
+            ObjectToAdd(
+                "more_test_data.txt",
+                content_type="text/plain",
+                reader=io.BytesIO(b"just some more test data"),
+                size=len(b"just some more test data"),
+            ),
+        ]
+        result = self.client.add_objects("example-dataset", *data)
+
+        if result.is_err():
+            raise result.value
+        ```
+        """
         errors: List[Exception] = []
         for obj in objects:
             result = self.add_object(
@@ -217,6 +335,7 @@ class DatasetClient:
     def delete(
         self, name: str
     ) -> Result[bool, Union[Exception, ExceptionGroup[RuntimeError]]]:
+        """Delete an existing dataset."""
         result = self._bucket_exists(name)
         if result.is_err():
             return result
@@ -241,6 +360,7 @@ class DatasetClient:
 
     @as_result
     def delete_object(self, name: str, object_name: str) -> None:
+        """Delete an object from an existing dataset."""
         result = self._bucket_exists(name)
         if result.is_err():
             return result
@@ -250,6 +370,7 @@ class DatasetClient:
     def delete_objects(
         self, name: str, *object_names: str
     ) -> Result[None, Union[Exception, ExceptionGroup[RuntimeError]]]:
+        """Delete one or more object from an existing dataset."""
         if not object_names:
             return Ok(None)
 

--- a/python/services/dataservice/dmod/dataservice/dataset_client.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_client.py
@@ -36,7 +36,7 @@ class DatasetClient:
         return self._client.bucket_exists(name)
 
     def _update_dataset(self, name: str) -> Result[None, Exception]:
-        with self.get_dataset(name) as res:
+        with self._get_dataset(name) as res:
             if res.is_err():
                 return res
 

--- a/python/services/dataservice/dmod/dataservice/dataset_client.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_client.py
@@ -31,6 +31,10 @@ class DatasetClient:
     def __init__(self, client: Minio) -> None:
         self._client = client
 
+    @classmethod
+    def _gen_dataset_serial_obj_name(cls, name: str) -> str:
+        return cls._SERIALIZED_OBJ_NAME_TEMPLATE.format(name)
+
     @as_result
     def _bucket_exists(self, name: str) -> bool:
         return self._client.bucket_exists(name)
@@ -46,7 +50,7 @@ class DatasetClient:
 
         return self.add_object(
             name=name,
-            object_name=self._SERIALIZED_OBJ_NAME_TEMPLATE.format(name),
+            object_name=self._gen_dataset_serial_obj_name(name),
             content_type="application/json",
             size=len(serial),
             reader=io.BytesIO(serial),
@@ -112,7 +116,7 @@ class DatasetClient:
         try:
             result = self.add_object(
                 name=name,
-                object_name=self._SERIALIZED_OBJ_NAME_TEMPLATE.format(name),
+                object_name=self._gen_dataset_serial_obj_name(name),
                 content_type="application/json",
                 reader=io.BytesIO(serialized),
                 size=len(serialized),

--- a/python/services/dataservice/dmod/dataservice/dataset_client.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_client.py
@@ -167,18 +167,16 @@ class DatasetClient:
         if result.is_err():
             return result
 
-        if size is None or size < 1:
-            size = -1
-        elif size > 5 * _MEGABYTE:
+        if size > 5 * _MEGABYTE:
             # TODO: determine appropriate partition size
-            partion_size = 5
+            partition_size = 5 * _MEGABYTE
             self._client.put_object(
                 bucket_name=name,
                 object_name=object_name,
                 data=reader,
                 length=size,
                 content_type=content_type,
-                part_size=partion_size,
+                part_size=partition_size,
                 metadata=headers,
             )
             return

--- a/python/services/dataservice/dmod/dataservice/dataset_client.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_client.py
@@ -1,0 +1,251 @@
+import io
+from minio import Minio
+from minio.deleteobjects import DeleteObject, DeleteError
+from typing import cast, Union, Iterable, List
+from dataclasses import dataclass
+from datetime import datetime
+from exceptiongroup import ExceptionGroup
+
+from .models import DataCategory, DataDomain
+from .dataset import Dataset
+from .result import Result, Ok, Err, as_result
+from .reader import Reader
+
+
+@dataclass
+class ObjectToAdd:
+    name: str
+    reader: Reader
+    size: Union[int, None] = None
+    content_type: str = "application/json"
+
+
+_MEGABYTE = 2**20
+
+
+class DatasetClient:
+    _SERIALIZED_OBJ_NAME_TEMPLATE = "{}_serialized.json"
+
+    def __init__(self, client: Minio) -> None:
+        self._client = client
+
+    @as_result
+    def _bucket_exists(self, name: str) -> bool:
+        return self._client.bucket_exists(name)
+
+    def _update_dataset(self, name: str) -> Result[None, Exception]:
+        with self.get_dataset(name) as res:
+            if res.is_err():
+                return res
+
+        ds: Dataset = res.value
+        ds.last_updated = datetime.now()
+        serial = ds.json(by_alias=True, exclude_none=True).encode()
+
+        return self.add_object(
+            name=name,
+            object_name=self._SERIALIZED_OBJ_NAME_TEMPLATE.format(name),
+            content_type="application/json",
+            size=len(serial),
+            reader=io.BytesIO(serial),
+        )
+
+    def _access_location(self, name: str) -> str:
+        return "{}://{}/{}".format(
+            "https" if self._client._base_url.is_https else "http",
+            self._client._base_url.host,
+            name,
+        )
+
+    def create(
+        self,
+        name: str,
+        category: DataCategory,
+        domain: DataDomain,
+        *objects: ObjectToAdd,
+        read_only: bool = False,
+    ) -> Result[Dataset, Union[Exception, ExceptionGroup[Exception]]]:
+        # NOTE: if minio-py changes their internal api this could fail in the future.
+        # if that happens, we want this to raise.
+        access_location = self._access_location(name)
+
+        try:
+            created_on = datetime.now()
+            # NOTE: could fail here
+            dataset = Dataset(
+                name=name,
+                category=category,
+                data_domain=domain,
+                access_location=access_location,
+                is_read_only=read_only,
+                created_on=created_on,
+                last_updated=created_on,
+            )
+
+            serialized = dataset.json(by_alias=True, exclude_none=True).encode()
+        except Exception as e:
+            return Err(e)
+
+        try:
+            self._client.make_bucket(name)
+        except Exception as e:
+            return Err(e)
+
+        try:
+            result = self.add_object(
+                name=name,
+                object_name=self._SERIALIZED_OBJ_NAME_TEMPLATE.format(name),
+                content_type="application/json",
+                reader=io.BytesIO(serialized),
+                size=len(serialized),
+            )
+
+            if result.is_err():
+                return result
+
+            if objects:
+                self.add_objects(name=name, *objects)
+
+            return Ok(dataset)
+
+        except Exception as e:
+            result = self.delete(name)
+            # if deletion fails, attach prior error context
+            if result.is_err():
+                result.value.__context__ = e
+                return result
+            return Err(e)
+
+    @as_result
+    def add_object(
+        self,
+        name: str,
+        object_name: str,
+        reader: Reader,
+        size: Union[int, None] = None,
+        content_type: str = "application/octet-stream",
+    ) -> None:
+        result = self._bucket_exists(name)
+        if result.is_err():
+            return result
+
+        if size is None or size < 1:
+            size = -1
+        elif size > 5 * _MEGABYTE:
+            # TODO: determine appropriate partition size
+            partion_size = 5
+            self._client.put_object(
+                bucket_name=name,
+                object_name=object_name,
+                data=reader,
+                length=size,
+                content_type=content_type,
+                part_size=partion_size,
+            )
+            return
+
+        self._client.put_object(
+            bucket_name=name,
+            object_name=object_name,
+            data=reader,
+            length=size,
+            content_type=content_type,
+        )
+
+    def add_objects(
+        self, name: str, *objects: ObjectToAdd
+    ) -> Result[None, ExceptionGroup[Exception]]:
+        errors: List[Exception] = []
+        for obj in objects:
+            result = self.add_object(
+                name=name,
+                object_name=obj.name,
+                reader=obj.reader,
+                size=obj.size,
+                content_type=obj.content_type,
+            )
+            if result.is_err():
+                # noop: cast to make linter happy
+                result = cast(Err[Exception], result)
+                errors.append(result.value)
+
+        if not errors:
+            return Ok(None)
+
+        if len(errors) == len(objects):
+            return Err(ExceptionGroup("all objects failed to upload", errors))
+        return Err(ExceptionGroup("some objects failed to upload", errors))
+
+    def delete(
+        self, name: str
+    ) -> Result[bool, Union[Exception, ExceptionGroup[RuntimeError]]]:
+        result = self._bucket_exists(name)
+        if result.is_err():
+            return result
+
+        if result.value is False:
+            return Ok(False)
+
+        object_listing = self._client.list_objects(bucket_name=name, recursive=True)
+        delete_object_list: List[str] = [x.object_name for x in object_listing]
+        result = self.delete_objects(name, *delete_object_list)
+
+        if result.is_err():
+            return result
+
+        try:
+            self._client.remove_bucket(name)
+        # catch, mainly, network errors
+        except Exception as e:
+            return Err(e)
+
+        return Ok(True)
+
+    @as_result
+    def delete_object(self, name: str, object_name: str) -> None:
+        result = self._bucket_exists(name)
+        if result.is_err():
+            return result
+
+        self._client.remove_object(bucket_name=name, object_name=object_name)
+
+    def delete_objects(
+        self, name: str, *object_names: str
+    ) -> Result[None, Union[Exception, ExceptionGroup[RuntimeError]]]:
+        if not object_names:
+            return Ok(None)
+
+        result = self._bucket_exists(name)
+        if result.is_err():
+            return result
+        if not result.value:
+            return Ok(None)
+
+        delete_object_list = list(map(lambda x: DeleteObject(x), object_names))
+        try:
+            errors: Iterable[DeleteError] = self._client.remove_objects(
+                bucket_name=name, delete_object_list=delete_object_list
+            )
+            errors = list(errors)
+        # catch, mainly, network errors
+        except Exception as e:
+            return Err(e)
+
+        if errors:
+            errs = [
+                RuntimeError(
+                    {
+                        "name": name,
+                        "object_name": e.name,
+                        "status_code": e.code,
+                        "message": e.message,
+                    }
+                )
+                for e in errors
+            ]
+
+            if len(errs) == len(object_names):
+                return Err(ExceptionGroup("error deleting all objects", errs))
+            return Err(ExceptionGroup("error deleting all objects", errs))
+
+        return Ok(None)

--- a/python/services/dataservice/dmod/dataservice/dataset_client.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_client.py
@@ -18,7 +18,7 @@ from .reader import Reader
 class ObjectToAdd:
     name: str
     reader: Reader
-    size: Union[int, None] = None
+    size: int
     content_type: str = "application/json"
 
 
@@ -140,7 +140,7 @@ class DatasetClient:
         name: str,
         object_name: str,
         reader: Reader,
-        size: Union[int, None] = None,
+        size: int,
         content_type: str = "application/octet-stream",
     ) -> None:
         result = self._bucket_exists(name)

--- a/python/services/dataservice/dmod/dataservice/dataset_query_client.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_query_client.py
@@ -2,12 +2,7 @@ import io
 from urllib3.response import HTTPResponse
 from minio import Minio, S3Error
 from minio.datatypes import Object as MinioObject, Bucket
-from typing import (
-    cast,
-    Dict,
-    Iterable,
-    Iterator,
-)
+from typing import cast, Dict, Iterable, Iterator, Optional
 from pydantic import BaseModel, UUID4
 from dataclasses import dataclass
 from contextlib import contextmanager
@@ -175,6 +170,12 @@ class DatasetQueryClient:
                     yield result
 
         return Ok(iterator())
+
+    @as_result
+    def list_dataset_objects(
+        self, name: str, prefix: Optional[str] = None, recursive: bool = False
+    ) -> Iterator[MinioObject]:
+        yield from self._client.list_objects(name, prefix=prefix, recursive=recursive)
 
     @property
     def datasets(self) -> Result[Iterator[Result[DatasetID, Exception]], Exception]:

--- a/python/services/dataservice/dmod/dataservice/dataset_query_client.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_query_client.py
@@ -1,0 +1,197 @@
+import io
+from urllib3.response import HTTPResponse
+from minio import Minio, S3Error
+from minio.datatypes import Object as MinioObject, Bucket
+from typing import (
+    cast,
+    Dict,
+    Iterable,
+    Iterator,
+)
+from pydantic import BaseModel, UUID4
+from dataclasses import dataclass
+from contextlib import contextmanager
+
+from .dataset import Dataset
+from .result import Result, Ok, Err, as_result
+from .utils import buffered_md5
+
+
+class DatasetID(BaseModel):
+    name: str
+    uuid: UUID4
+
+
+@dataclass
+class DatasetCacheItem:
+    dataset: Dataset
+    hash: str
+
+
+class DatasetQueryClient:
+    _SERIALIZED_OBJ_NAME_TEMPLATE = "{}_serialized.json"
+
+    def __init__(self, client: Minio) -> None:
+        self._client = client
+        self._ds_cache: Dict[str, DatasetCacheItem] = dict()
+
+    def _gen_dataset_serial_obj_name(self, name: str) -> str:
+        return self._SERIALIZED_OBJ_NAME_TEMPLATE.format(name)
+
+    @as_result
+    def _load_dataset_from_cache(self, name: str) -> Dataset:
+        # load dataset from cache
+        ds = self._ds_cache.get(name, None)
+
+        metadata_file_name = self._gen_dataset_serial_obj_name(name)
+
+        # cache miss
+        if ds is None:
+            with self.get_dataset_object(name, metadata_file_name) as result:
+                # fail fast, may want return and backoff here in the future
+                if result.is_err():
+                    return result
+
+                raw_body = result.value.read()
+            deserialized = Dataset.parse_raw(raw_body)
+            ds = DatasetCacheItem(deserialized, buffered_md5(io.BytesIO(raw_body)))
+
+        # get object metadata from object store. this includes md5 hash (etag)
+        result = self.get_dataset_object_info(name, metadata_file_name)
+        # failed to get metadata from object store
+        if result.is_err():
+            # if the bucket or object does not exist, purge from cache
+            # see s3 error codes: https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList
+            if type(result.value) == S3Error and result.value.code in (
+                "NoSuchBucket",
+                "NoSuchKey",
+            ):
+                self._ds_cache.pop(name, None)
+
+            return result
+
+        remote_ds_hash: str = result.value.etag
+
+        # invalidate cache and retry
+        if ds.hash != remote_ds_hash:
+            self._ds_cache.pop(name, None)
+            return self._load_dataset_from_cache(name)
+
+        # cache dataset
+        self._ds_cache[name] = ds
+
+        return ds.dataset
+
+    def dataset_exists(self, name: str) -> Result[bool, Exception]:
+        with self.get_dataset(name) as result:
+            if result.is_ok():
+                return Ok(True)
+
+            # failed to get dataset; check if bucket or object does not exist
+            # see s3 error codes: https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList
+            if type(result.value) == S3Error and result.value.code in (
+                "NoSuchBucket",
+                "NoSuchKey",
+            ):
+                return Ok(False)
+
+            return result
+
+    @contextmanager
+    def _get_raw_dataset(self, name: str) -> Iterator[Result[bytes, Exception]]:
+        """"""
+        try:
+            response: HTTPResponse = self._client.get_object(
+                name, self._gen_dataset_serial_obj_name(name)
+            )
+            yield Ok(response.read())
+        except Exception as e:
+            yield Err(e)
+        finally:
+            response.close()
+            response.release_conn()
+
+    @contextmanager
+    def get_dataset(self, name: str) -> Iterator[Result[Dataset, Exception]]:
+        # try load from cache
+        result = self._load_dataset_from_cache(name)
+        if result.is_ok():
+            yield result
+            return
+
+        response_bound = False
+        try:
+            response: HTTPResponse = self._client.get_object(
+                name, self._gen_dataset_serial_obj_name(name)
+            )
+            response_bound = True
+            yield Ok(Dataset.parse_raw(response.read()))
+        except Exception as e:
+            yield Err(e)
+        finally:
+            if response_bound:
+                response.close()
+                response.release_conn()
+
+    def get_dataset_id(self, name: str) -> Result[UUID4, Exception]:
+        with self.get_dataset(name) as result:
+            if result.is_err():
+                return result
+            return Ok(result.value.uuid)
+
+    @contextmanager
+    def get_dataset_object(
+        self, name: str, object_name: str
+    ) -> Iterator[Result[HTTPResponse, Exception]]:
+        response_bound = False
+        try:
+            response: HTTPResponse = self._client.get_object(
+                bucket_name=name, object_name=object_name
+            )
+            response_bound = True
+            yield Ok(response)
+        except Exception as e:
+            yield Err(e)
+        finally:
+            if response_bound:
+                response.close()
+                response.release_conn()
+
+    @as_result
+    def get_dataset_object_info(self, name: str, object_name: str) -> MinioObject:
+        return self._client.stat_object(bucket_name=name, object_name=object_name)
+
+    def get_all_datasets(
+        self,
+    ) -> Result[Iterator[Result[Dataset, Exception]], Exception]:
+        try:
+            buckets: Iterable[Bucket] = self._client.list_buckets()
+        except Exception as e:
+            return Err(e)
+
+        def iterator():
+            for b in buckets:
+                with self.get_dataset(b.name) as result:
+                    yield result
+
+        return Ok(iterator())
+
+    @property
+    def datasets(self) -> Result[Iterator[Result[DatasetID, Exception]], Exception]:
+        result = self.get_all_datasets()
+        if result.is_err():
+            result = cast(Err[Exception], result)
+            return result
+
+        result = cast(Ok[Iterator[Result[Dataset, Exception]]], result)
+
+        def iterator() -> Iterator[Result[DatasetID, Exception]]:
+            for ds in result.value:
+                if ds.is_ok():
+                    ds = cast(Ok[Dataset], ds)
+                    yield Ok(DatasetID(name=ds.value.name, uuid=ds.value.uuid))
+                else:
+                    ds = cast(Err[Exception], ds)
+                    yield ds
+
+        return Ok(iterator())

--- a/python/services/dataservice/dmod/dataservice/reader.py
+++ b/python/services/dataservice/dmod/dataservice/reader.py
@@ -1,0 +1,6 @@
+from typing import Protocol, Union
+
+
+class Reader(Protocol):
+    def read(self, size: Union[int, None] = ...) -> bytes:
+        ...

--- a/python/services/dataservice/dmod/dataservice/result.py
+++ b/python/services/dataservice/dmod/dataservice/result.py
@@ -1,0 +1,100 @@
+import sys
+import types
+from dataclasses import dataclass
+from functools import wraps
+from typing import TypeVar, Generic, NoReturn, Literal, Union, Callable
+from typing_extensions import TypeAlias, ParamSpec
+
+T = TypeVar("T", covariant=True)
+E = TypeVar("E", covariant=True, bound=BaseException)
+U = TypeVar("U")
+
+
+def try_attach_traceback_to_exception(exception: E, depth: int = 0) -> bool:
+    # inspiration from https://stackoverflow.com/a/54653137
+    # depth of 1 means to start from the caller's frame
+
+    # > CPython implementation detail: This function should be used for internal and specialized
+    # > purposes only. It is not guaranteed to exist in all implementations of Python.
+    # https://docs.python.org/3.7/library/sys.html#sys._getframe
+    frame = sys._getframe(depth) if hasattr(sys, "_getframe") else None
+    if frame is None:
+        return False
+
+    tb = types.TracebackType(None, frame, frame.f_lasti, frame.f_lineno)
+    exception.with_traceback(tb)
+    return True
+
+
+@dataclass
+class Ok(Generic[T]):
+    value: T
+
+    def is_ok(self) -> Literal[True]:
+        return True
+
+    def is_err(self) -> Literal[False]:
+        return False
+
+    def unwrap(self) -> T:
+        return self.value
+
+    def unwrap_or(self, default: U) -> T:
+        return self.value
+
+    def unwrap_or_else(self, fn: Callable[[E], T]) -> T:
+        return self.value
+
+
+@dataclass
+class Err(Generic[E]):
+    value: E
+
+    def __post_init__(self):
+        if self.value.__traceback__ is None:
+            # start from stack depth 3 so trace starts from call to initialize Error:
+            # 0: try_attach_traceback_to_exception
+            # 1: __post_init__
+            # 2: __init__ (implicit b.c. dataclass)
+            # 3: caller that created Error
+            # if successful, this mutates self.value.__traceback__
+            try_attach_traceback_to_exception(self.value, depth=3)
+
+    def is_ok(self) -> Literal[False]:
+        return False
+
+    def is_err(self) -> Literal[True]:
+        return True
+
+    def unwrap(self) -> NoReturn:
+        raise ValueError("Called `Result.unwrap()` on an `Err` value") from self.value
+
+    def unwrap_or(self, default: U) -> U:
+        return default
+
+    def unwrap_or_else(self, fn: Callable[[E], T]) -> T:
+        return fn(self.value)
+
+
+Result: TypeAlias = Union[Ok[T], Err[E]]
+
+ReturnType = TypeVar("ReturnType")
+Parms = ParamSpec("Parms")
+
+
+def as_result(
+    fn: Callable[Parms, ReturnType]
+) -> Callable[Parms, Result[ReturnType, Exception]]:
+    @wraps(fn)
+    def inner(
+        *args: Parms.args, **kwargs: Parms.kwargs
+    ) -> Result[ReturnType, Exception]:
+        try:
+            res = fn(*args, **kwargs)
+            if isinstance(res, Err):
+                return res
+            return Ok(res)
+        except Exception as e:
+            return Err(e)
+
+    return inner

--- a/python/services/dataservice/dmod/dataservice/utils.py
+++ b/python/services/dataservice/dmod/dataservice/utils.py
@@ -1,0 +1,16 @@
+import hashlib
+
+from .reader import Reader
+
+# size of page in most x86 unix systems
+FOUR_K = 4096
+
+
+def buffered_md5(r: Reader, block_size: int = FOUR_K) -> str:
+    h = hashlib.md5(usedforsecurity=False)
+    chunk = r.read(block_size)
+    while chunk:
+        h.update(chunk)
+        chunk = r.read(block_size)
+
+    return h.hexdigest()

--- a/python/services/dataservice/dmod/dataservice/utils.py
+++ b/python/services/dataservice/dmod/dataservice/utils.py
@@ -1,3 +1,4 @@
+import sys
 import hashlib
 
 from .reader import Reader
@@ -7,7 +8,10 @@ FOUR_K = 4096
 
 
 def buffered_md5(r: Reader, block_size: int = FOUR_K) -> str:
-    h = hashlib.md5(usedforsecurity=False)
+    if sys.version_info >= (3, 9):
+        h = hashlib.md5(usedforsecurity=False)
+    else:
+        h = hashlib.md5()
     chunk = r.read(block_size)
     while chunk:
         h.update(chunk)

--- a/python/services/dataservice/dmod/test/it_dataset_client.py
+++ b/python/services/dataservice/dmod/test/it_dataset_client.py
@@ -1,0 +1,22 @@
+import os
+from minio import Minio
+from typing import Optional
+
+from .test_dataset_client import TestDatasetClient
+
+
+def setup_minio_client() -> Minio:
+    default_key = "minioadmin"
+    host = os.environ.get("MINIO_HOST", "127.0.0.1")
+    port = os.environ.get("MINIO_PORT", "9000")
+    key = os.environ.get("MINIO_KEY", default_key)
+    secret = os.environ.get("MINIO_SECRET", default_key)
+    secure = bool(os.environ.get("MINIO_SECURE", False))
+
+    return Minio(f"{host}:{port}", access_key=key, secret_key=secret, secure=secure)
+
+
+class IntegrationTestDatasetQueryClient(TestDatasetClient):
+    def setUp(self, minio_client: Optional[Minio] = None) -> None:
+        minio_client = setup_minio_client()
+        super().setUp(minio_client)

--- a/python/services/dataservice/dmod/test/it_dataset_query_client.py
+++ b/python/services/dataservice/dmod/test/it_dataset_query_client.py
@@ -1,0 +1,22 @@
+import os
+from minio import Minio
+from typing import Optional
+
+from .test_dataset_query_client import TestDatasetQueryClient
+
+
+def setup_minio_client() -> Minio:
+    default_key = "minioadmin"
+    host = os.environ.get("MINIO_HOST", "127.0.0.1")
+    port = os.environ.get("MINIO_PORT", "9000")
+    key = os.environ.get("MINIO_KEY", default_key)
+    secret = os.environ.get("MINIO_SECRET", default_key)
+    secure = bool(os.environ.get("MINIO_SECURE", False))
+
+    return Minio(f"{host}:{port}", access_key=key, secret_key=secret, secure=secure)
+
+
+class IntegrationTestDatasetQueryClient(TestDatasetQueryClient):
+    def setUp(self, minio_client: Optional[Minio] = None) -> None:
+        minio_client = setup_minio_client()
+        super().setUp(minio_client)

--- a/python/services/dataservice/dmod/test/minio_mock.py
+++ b/python/services/dataservice/dmod/test/minio_mock.py
@@ -1,0 +1,299 @@
+import io
+import re
+import datetime
+import mimetypes
+from minio import S3Error
+from minio.datatypes import Bucket, Object
+from minio.deleteobjects import DeleteObject, DeleteError
+from minio.helpers import BaseURL
+from pathlib import Path
+from dataclasses import dataclass
+from tempfile import TemporaryDirectory
+
+from ..dataservice.utils import buffered_md5
+from ..dataservice.reader import Reader
+
+from typing import Any, Dict, Optional, List, Iterable
+
+
+@dataclass
+class HTTPResponseMock:
+    data: Reader
+
+    def __post_init__(self):
+        self._open = True
+
+    def read(self, amt=None, decode_content=None, cache_content=False):
+        if self._open:
+            return self.data.read(amt)
+        return b""
+
+    def close(self):
+        self._open = False
+
+    def release_conn(self):
+        self.data = None
+
+
+class MinioMock:
+    """
+    A mostly complete Minio's api that stores buckets and objects in a self managed temporary
+    directory.
+    """
+
+    _BUCKET_NAME_RE = re.compile(
+        "(?!(^xn--|.+-s3alias$))^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$"
+    )
+
+    def __init__(
+        self,
+        endpoint: str,
+        access_key=None,
+        secret_key=None,
+        session_token=None,
+        secure=True,
+        region=None,
+        http_client=None,
+        credentials=None,
+    ):
+        self._base_url = BaseURL(
+            ("https://" if secure else "http://") + endpoint,
+            region,
+        )
+        self._temp_dir = TemporaryDirectory()
+
+    def __del__(self):
+        self._temp_dir.cleanup()
+
+    @property
+    def _temp_dir_path(self) -> Path:
+        return Path(self._temp_dir.name)
+
+    @staticmethod
+    def _timestamp_as_utc_dt(t: float) -> datetime.datetime:
+        creation_date = datetime.datetime.utcfromtimestamp(t)
+        return creation_date.replace(tzinfo=datetime.timezone.utc)
+
+    @staticmethod
+    def _build_s3_error(
+        code: str,
+        message: str,
+        bucket_name: Optional[str] = None,
+        object_name: Optional[str] = None,
+    ) -> S3Error:
+        return S3Error(
+            code=code,
+            message=message,
+            resource="",
+            request_id="",
+            host_id="",
+            response="",
+            bucket_name=bucket_name,
+            object_name=object_name,
+        )
+
+    def _object_exists(self, bucket_name: str, object_name: str) -> bool:
+        o = self._temp_dir_path / bucket_name / object_name
+        return o.exists() and not o.is_dir()
+
+    def make_bucket(self, bucket_name: str, location=None, object_lock=False):
+        if self._BUCKET_NAME_RE.fullmatch(bucket_name) is None:
+            # TODO
+            raise ValueError
+
+        (self._temp_dir_path / bucket_name).mkdir()
+
+    def put_object(
+        self,
+        bucket_name: str,
+        object_name: str,
+        data: Reader,
+        length: int,
+        content_type="application/octet-stream",
+        metadata: Optional[Dict[str, Any]] = None,
+        sse=None,
+        progress=None,
+        part_size=0,
+        num_parallel_uploads=3,
+        tags=None,
+        retention=None,
+        legal_hold=False,
+    ):
+        if not self.bucket_exists(bucket_name):
+            raise self._build_s3_error(
+                "NoSuchBucket", "Bucket does not exist", bucket_name=bucket_name
+            )
+
+        with open(self._temp_dir_path / bucket_name / object_name, "wb") as fp:
+            fp.write(data.read())
+
+    def bucket_exists(self, bucket_name: str) -> bool:
+        return (self._temp_dir_path / bucket_name).exists()
+
+    def list_buckets(self) -> List[Bucket]:
+        buckets: List[Bucket] = []
+        for dir in filter(lambda p: p.is_dir(), self._temp_dir_path.glob("*")):
+            dir_stat = dir.stat()
+            creation_date = datetime.datetime.utcfromtimestamp(dir_stat.st_ctime)
+            creation_date = creation_date.replace(tzinfo=datetime.timezone.utc)
+            buckets.append(Bucket(name=dir.name, creation_date=creation_date))
+
+        return buckets
+
+    def list_objects(
+        self,
+        bucket_name: str,
+        prefix: Optional[str] = None,
+        recursive: bool = False,
+        start_after=None,
+        include_user_meta=False,
+        include_version=False,
+        use_api_v1=False,
+        use_url_encoding_type=True,
+        fetch_owner=False,
+    ):
+        if prefix is not None:
+            raise NotImplemented
+
+        gen = (
+            self._temp_dir_path.glob("**/*")
+            if recursive
+            else self._temp_dir_path.glob("*")
+        )
+
+        for file in gen:
+            if file.is_dir():
+                continue
+            object_name = file.name
+            file_stat = file.stat()
+            last_modified = self._timestamp_as_utc_dt(file_stat.st_mtime)
+            size = file_stat.st_size
+            with open(file, "rb") as fp:
+                etag = buffered_md5(fp)
+
+            yield Object(
+                bucket_name,
+                object_name,
+                last_modified=last_modified,
+                etag=etag,
+                size=size,
+                metadata={},
+                version_id=None,
+                is_latest=None,
+                storage_class="STANDARD",
+                owner_id=None,
+                owner_name="minio",
+                content_type=None,
+                is_delete_marker=False,
+            )
+
+    def remove_bucket(self, bucket_name: str):
+        if not self.bucket_exists(bucket_name):
+            raise self._build_s3_error(
+                "NoSuchBucket", "Bucket does not exist", bucket_name=bucket_name
+            )
+        (self._temp_dir_path / bucket_name).rmdir()
+
+    def get_object(
+        self,
+        bucket_name: str,
+        object_name: str,
+        offset: int = 0,
+        length: int = 0,
+        request_headers=None,
+        ssec=None,
+        version_id=None,
+        extra_query_params=None,
+    ) -> HTTPResponseMock:
+        if not self.bucket_exists(bucket_name):
+            raise self._build_s3_error(
+                "NoSuchBucket", "Bucket does not exist", bucket_name=bucket_name
+            )
+
+        if not self._object_exists(bucket_name, object_name):
+            raise self._build_s3_error(
+                "NoSuchKey",
+                "Object does not exist",
+                bucket_name=bucket_name,
+                object_name=object_name,
+            )
+
+        return HTTPResponseMock(
+            io.BytesIO((self._temp_dir_path / bucket_name / object_name).read_bytes())
+        )
+
+    def stat_object(
+        self,
+        bucket_name: str,
+        object_name: str,
+        ssec=None,
+        version_id=None,
+        extra_query_params=None,
+    ) -> Object:
+        if not self.bucket_exists(bucket_name):
+            raise self._build_s3_error("NoSuchBucket", "Bucket does not exist")
+
+        if not self._object_exists(bucket_name, object_name):
+            raise self._build_s3_error("NoSuchKey", "Object does not exist")
+
+        mt = mimetypes.MimeTypes()
+        mime_type, _ = mt.guess_type(object_name)
+
+        file = self._temp_dir_path / bucket_name / object_name
+        if file.is_dir():
+            # TODO
+            raise ValueError
+
+        file_stat = file.stat()
+        last_modified = self._timestamp_as_utc_dt(file_stat.st_mtime)
+        size = file_stat.st_size
+        with open(file, "rb") as fp:
+            etag = buffered_md5(fp)
+
+        return Object(
+            bucket_name,
+            object_name,
+            last_modified=last_modified,
+            etag=etag,
+            size=size,
+            metadata={},
+            version_id=None,
+            is_latest=None,
+            storage_class="STANDARD",
+            owner_id=None,
+            owner_name="minio",
+            content_type=mime_type,
+            is_delete_marker=False,
+        )
+
+    def remove_object(self, bucket_name: str, object_name: str, version_id=None):
+        if not self.bucket_exists(bucket_name):
+            raise self._build_s3_error("NoSuchBucket", "Bucket does not exist")
+
+        if not self._object_exists(bucket_name, object_name):
+            raise self._build_s3_error("NoSuchKey", "Object does not exist")
+
+        o = self._temp_dir_path / bucket_name / object_name
+        o.unlink()
+
+    def remove_objects(
+        self,
+        bucket_name: str,
+        delete_object_list: Iterable[DeleteObject],
+        bypass_governance_mode: bool = False,
+    ):
+        errors: List[DeleteError] = []
+        for object in delete_object_list:
+            try:
+                self.remove_object(bucket_name, object._name)
+
+            except S3Error as e:
+                errors.append(
+                    DeleteError(
+                        code=e.code,
+                        message=e.message,
+                        name=object._name,
+                        version_id=None,
+                    )
+                )
+        return errors

--- a/python/services/dataservice/dmod/test/minio_mock.py
+++ b/python/services/dataservice/dmod/test/minio_mock.py
@@ -297,6 +297,19 @@ class MinioMock:
         o = self._temp_dir_path / bucket_name / object_name
         o.unlink()
 
+        # directories are fictitious in the object store's perspective. when objects are removed
+        # from the object store, we need to also remove any empty predecessor directories.
+        dir = o.parent
+        while self._temp_dir_path / bucket_name != dir:
+            # check if directory has files
+            try:
+                next(dir.glob("**/*"))
+                # there must be files that exist
+                return
+            except StopIteration:
+                dir.rmdir()
+                dir = dir.parent
+
     def remove_objects(
         self,
         bucket_name: str,

--- a/python/services/dataservice/dmod/test/test_dataset_client.py
+++ b/python/services/dataservice/dmod/test/test_dataset_client.py
@@ -1,0 +1,151 @@
+import unittest
+import io
+import time
+from minio import Minio, S3Error
+from typing import Optional
+
+from ..dataservice.dataset_client import DatasetClient, ObjectToAdd
+from ..dataservice.dataset import Dataset
+from ..dataservice.models import (
+    StandardDatasetIndex,
+    DataCategory,
+    DataDomain,
+    DataFormat,
+    DiscreteRestriction,
+)
+from .minio_mock import MinioMock
+
+
+class TestDatasetClient(unittest.TestCase):
+    def setUp(self, minio_client: Optional[Minio] = None) -> None:
+        if minio_client is None:
+            self.minio_client = MinioMock(endpoint="127.0.0.1:9000")
+        else:
+            self.minio_client = minio_client
+
+        self.client = DatasetClient(self.minio_client)
+        self.dataset = self.create_test_dataset("test-dataset")
+
+    def tearDown(self) -> None:
+        self.clean_up_test_dataset("test-dataset")
+
+    def create_test_dataset(self, name: str) -> Dataset:
+        result = self.client.create(
+            name,
+            category=DataCategory.CONFIG,
+            domain=DataDomain(
+                data_format=DataFormat.BMI_CONFIG,
+                discrete=[
+                    DiscreteRestriction(
+                        variable=StandardDatasetIndex.GLOBAL_CHECKSUM, values=["42"]
+                    )
+                ],
+            ),
+        )
+        if result.is_err():
+            raise Exception from result.value
+
+        return result.value
+
+    def clean_up_test_dataset(self, name: str):
+        result = self.client.delete(name)
+        if result.is_ok():
+            return
+
+        # see s3 error codes: https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList
+        if type(result.value) == S3Error and result.value.code in (
+            "NoSuchBucket",
+            "NoSuchKey",
+        ):
+            return
+
+        raise result.value
+
+    def test__bucket_exists(self):
+        name = self.dataset.name
+        result = self.client._bucket_exists(name)
+        assert result.unwrap() == True
+
+        result = self.client.delete(name)
+        assert result.unwrap() == True
+
+        result = self.client._bucket_exists(name)
+        assert result.unwrap() == False
+
+    def test_update_dataset(self):
+        # updating a dataset entails updating its `last_updated` property. the `last_updated` property
+        # stored with second precision, ergo, it's required to wait a moment to verify this case.
+        time.sleep(1.1)
+        result = self.client._update_dataset(self.dataset.name)
+        # throw if `is_err`
+        result.unwrap()
+        with self.client._get_dataset(self.dataset.name) as result:
+            updated_dataset = result.unwrap()
+        assert updated_dataset.last_updated > self.dataset.last_updated
+
+    def test_add_object(self):
+        name = self.dataset.name
+        result = self.client.add_object(
+            name=name,
+            object_name="test_data.txt",
+            reader=io.BytesIO(b"just some test data"),
+            content_type="text/plain",
+            size=len(b"just some test data"),
+        )
+        result.unwrap()
+
+    def test_add_objects(self):
+        name = self.dataset.name
+        data = [
+            ObjectToAdd(
+                "test_data.txt",
+                content_type="text/plain",
+                reader=io.BytesIO(b"just some test data"),
+                size=len(b"just some test data"),
+            ),
+            ObjectToAdd(
+                "more_test_data.txt",
+                content_type="text/plain",
+                reader=io.BytesIO(b"just some more test data"),
+                size=len(b"just some more test data"),
+            ),
+        ]
+        result = self.client.add_objects(name, *data)
+        result.unwrap()
+
+        for item in data:
+            result = self.client.delete_object(name=name, object_name=item.name)
+            assert result.is_ok()
+
+    def test_delete(self):
+        result = self.client.delete(self.dataset.name)
+        result.unwrap()
+
+        ds_exists = self.client._bucket_exists(self.dataset.name).unwrap()
+        assert ds_exists is False
+
+    def test_delete_objects(self):
+        # setup
+        name = self.dataset.name
+        data = [
+            ObjectToAdd(
+                "test_data.txt",
+                content_type="text/plain",
+                reader=io.BytesIO(b"just some test data"),
+                size=len(b"just some test data"),
+            ),
+            ObjectToAdd(
+                "folder/more_test_data.txt",
+                content_type="text/plain",
+                reader=io.BytesIO(b"just some more test data"),
+                size=len(b"just some more test data"),
+            ),
+        ]
+        result = self.client.add_objects(name, *data)
+        result.unwrap()
+
+        # thing we are actually testing
+        result = self.client.delete_objects(
+            name, "test_data.txt", "folder/more_test_data.txt"
+        )
+        assert result.is_ok()

--- a/python/services/dataservice/dmod/test/test_dataset_query_client.py
+++ b/python/services/dataservice/dmod/test/test_dataset_query_client.py
@@ -1,0 +1,165 @@
+import json
+import io
+import unittest
+import os
+from minio import Minio, S3Error
+from typing import Optional
+
+from ..dataservice.dataset import Dataset
+from ..dataservice.models import (
+    StandardDatasetIndex,
+    DataCategory,
+    DataDomain,
+    DataFormat,
+    DiscreteRestriction,
+)
+from ..dataservice.dataset_query_client import DatasetQueryClient
+from ..dataservice.dataset_client import DatasetClient
+from ..dataservice.utils import buffered_md5
+
+from .minio_mock import MinioMock
+
+
+class TestDatasetQueryClient(unittest.TestCase):
+    def setUp(self, minio_client: Optional[Minio] = None) -> None:
+        if minio_client is None:
+            self.minio_client = MinioMock(endpoint="127.0.0.1:9000")
+        else:
+            self.minio_client = minio_client
+
+        self.client = DatasetQueryClient(self.minio_client)
+        self.dataset = self.create_test_dataset("test-dataset")
+
+    def tearDown(self) -> None:
+        self.clean_up_test_dataset("test-dataset")
+
+    def create_test_dataset(self, name: str) -> Dataset:
+        ds_client = DatasetClient(self.minio_client)
+        result = ds_client.create(
+            name,
+            category=DataCategory.CONFIG,
+            domain=DataDomain(
+                data_format=DataFormat.BMI_CONFIG,
+                discrete=[
+                    DiscreteRestriction(
+                        variable=StandardDatasetIndex.GLOBAL_CHECKSUM, values=["42"]
+                    )
+                ],
+            ),
+        )
+        if result.is_err():
+            raise Exception from result.value
+
+        return result.value
+
+    def clean_up_test_dataset(self, name: str):
+        ds_client = DatasetClient(self.minio_client)
+        result = ds_client.delete(name)
+        if result.is_ok():
+            return
+
+        # see s3 error codes: https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html#ErrorCodeList
+        if type(result.value) == S3Error and result.value.code in (
+            "NoSuchBucket",
+            "NoSuchKey",
+        ):
+            return
+
+        raise result.value
+
+    def test_cache(self):
+        name = self.dataset.name
+        assert len(self.client._ds_cache) == 0, "cache should be empty"
+        result = self.client._load_dataset_from_cache(name)
+        assert result.is_ok(), result.unwrap()
+        assert (
+            name in self.client._ds_cache
+        ), f"dataset name: {name!r} should be in cache"
+        assert self.dataset == result.value, "cached dataset should match"
+
+        ds_client = DatasetClient(self.minio_client)
+        # delete dataset
+        result = ds_client.delete(name)
+        assert (
+            result.is_ok() and result.value
+        ), f"dataset {name!r} was not successfully deleted"
+
+        result = self.client._load_dataset_from_cache(name)
+        assert result.is_err(), "dataset has been deleted, so it should not be present"
+        assert (
+            name not in self.client._ds_cache
+        ), f"dataset name: {name!r} should not be in cache"
+        assert type(result.value) == S3Error
+        assert result.value.code == "NoSuchBucket"
+
+    def test_dataset_exists_is_true(self):
+        result = self.client.dataset_exists(self.dataset.name)
+        assert result.is_ok()
+        assert result.value is True
+
+    def test_dataset_exists_is_false(self):
+        result = self.client.dataset_exists("some-fake-dataset")
+        assert result.is_ok()
+        assert result.value is False
+
+    def test_get_dataset(self):
+        with self.client.get_dataset(self.dataset.name) as result:
+            ds = result.unwrap()
+            assert ds == self.dataset
+
+    def test_get_dataset_id(self):
+        result = self.client.get_dataset_id(self.dataset.name)
+        assert result.unwrap() == self.dataset.uuid
+
+    def test_get_dataset_object_info(self):
+        result = self.client.get_dataset_object_info(
+            self.dataset.name,
+            self.client._gen_dataset_serial_obj_name(self.dataset.name),
+        )
+        info = result.unwrap()
+        assert info.bucket_name == self.dataset.name
+        assert info.content_type == "application/json"
+        md5 = buffered_md5(
+            io.BytesIO(self.dataset.json(by_alias=True, exclude_none=True).encode())
+        )
+        assert info.etag == md5
+
+    def test_get_all_datasets(self):
+        result = self.client.get_all_datasets()
+        for ds in result.unwrap():
+            if ds.unwrap() == self.dataset:
+                return
+
+        raise ValueError(f"dataset: {self.dataset} should be in list of all datasets.")
+
+    def test_datasets(self):
+        for ds in self.client.datasets.unwrap():
+            if ds.unwrap().uuid == self.dataset.uuid:
+                return
+
+        raise ValueError(
+            f"dataset uuid: {self.dataset} should be in list of all dataset's uuid's"
+        )
+
+    def test_get_dataset_object(self):
+        # extra setup
+        data = {"topic": "testing", "payload": "success"}
+        raw_data = json.dumps(data).encode()
+        reader = io.BytesIO(raw_data)
+        object_name = "test.json"
+
+        ds_client = DatasetClient(self.minio_client)
+        result = ds_client.add_object(
+            content_type="application/json",
+            name=self.dataset.name,
+            object_name=object_name,
+            reader=reader,
+            size=len(raw_data),
+        )
+        if result.is_err():
+            raise result.value
+
+        # actual testing
+        with self.client.get_dataset_object(self.dataset.name, object_name) as result:
+            result_data = json.loads(result.unwrap().read().decode())
+        assert result_data == data

--- a/python/services/dataservice/setup.py
+++ b/python/services/dataservice/setup.py
@@ -19,6 +19,6 @@ setup(
     license='',
     install_requires=["dmod-core>=0.5.0", "dmod-communication>=0.13.0", "dmod-scheduler>=0.10.0",
                       "dmod-modeldata>=0.9.0", 'redis', "pydantic", "fastapi", "uvicorn[standard]",
-                      "ngen-config>=0.1.1"],
+                      "ngen-config>=0.1.1", "exceptiongroup"],
     packages=find_namespace_packages(exclude=['dmod.test', 'deprecated', 'conf', 'schemas', 'ssl', 'src'])
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,3 +60,4 @@ shapely>=2.0.0
 pydantic
 git+https://github.com/NOAA-OWP/ngen-cal@master#egg=ngen-config&subdirectory=python/ngen_conf
 exceptiongroup
+fastapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,3 +59,4 @@ pyparsing
 shapely>=2.0.0
 pydantic
 git+https://github.com/NOAA-OWP/ngen-cal@master#egg=ngen-config&subdirectory=python/ngen_conf
+exceptiongroup


### PR DESCRIPTION
The second phase of refactoring the data service. This phase focuses on rewriting library code that supports reading and writing to and from the object store (related #323). Much of this work will eventually be migrated into `dmod.metadata`, but for now, it will live in the service as it is the sole user.

## Additions

- `DatasetClient` and `DatasetQueryClient`. These classes separate the concerns of reading and writing to a data store (e.g. `minio`) and functionally replace `ObjectStoreDatasetManager`.
- `Result` type that conceptually functions like a enum of either `Ok(T)` or `Err(E)`. This forces users to explicitly handle errors and enables treating exceptions types as values. This addition was heavily inspired by [Rust's `Result` type](https://doc.rust-lang.org/std/result/).
- Picked up `exceptiongroup`. "This is a backport of the BaseExceptionGroup and ExceptionGroup classes from Python 3.11." [source](https://pypi.org/project/exceptiongroup/1.1.1/).

## Testing

1. Unit and integration tests for `DatasetClient` and `DatasetQueryClient`'s are added.


## Todos

- [x] Add integration tests (this is mostly done)
- [x] Add doc strings
- [x] Add unit tests


## Checklist

- [x] PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (link if applicable)
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output)
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right: