### PR TITLE
Adopt deployx plugin for stack deployment in control scripts

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,12 +6,12 @@ Detailed instructions on how to install, configure, and get the project running.
 
 - Install project [dependencies](doc/DEPENDENCIES.md)
   - Optionally, setup and use a [dedicated Python virtual environment](#using-a-virtual-environment) (highly recommended)
-- Create a [customized local config](#local-configuration)
+- Create a [customized local environment config](#local-environment-configuration)
 - Set up the [required SSL certificates](#local-ssl-certs)
 - Build and install necessary [internal Python packages](#python-packages-and-dependencies) into Python environment, typically using the [provided helper script](#using-update_packagesh-for-dependencies-and-internal-packages)
 - [Build Docker images](#docker-images)
 
-## Local Configuration
+## Local Environment Configuration
 
 Each local deployment and/or development environment requires its own configuration be set up in order to function properly.  This is currently done via a local environment file.  
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ More detailed information can be found on the [Dependencies](doc/DEPENDENCIES.md
 
 The basic process is:
 - Install project [dependencies](doc/DEPENDENCIES.md)
-  - Optionally, setup and use a [dedicated Python virtual environment](#using-a-virtual-environment) (highly recommended)
-- Create a [customized local config](#local-configuration)
-- Set up the [required SSL certificates](#local-ssl-certs)
-- Build and install necessary [internal Python packages](#python-packages-and-dependencies) into Python environment, typically using the [provided helper script](#using-update_packagesh-for-dependencies-and-internal-packages)
-- [Build Docker images](#docker-images)
+  - Optionally, setup and use a [dedicated Python virtual environment](INSTALL.md#using-a-virtual-environment) (highly recommended)
+- Create a [customized local environment config](INSTALL.md#local-environment-configuration)
+- Set up the [required SSL certificates](INSTALL.md#local-ssl-certs)
+- Build and install necessary [internal Python packages](INSTALL.md#python-packages-and-dependencies) into Python environment, typically using the [provided helper script](#using-update_packagesh-for-dependencies-and-internal-packages)
+- [Build Docker images](INSTALL.md#docker-images)
 
 See the [INSTALL](INSTALL.md) document for more information.
 

--- a/doc/DEPENDENCIES.md
+++ b/doc/DEPENDENCIES.md
@@ -7,12 +7,13 @@ The DMOD project has two related sets of dependencies:
 
 ## Usage Dependencies
 
-| Dependency         | Constraints                                 |                                             Notes                                              |
-|--------------------|:--------------------------------------------|:----------------------------------------------------------------------------------------------:|
-| Docker Engine      | \>=20.10.16                                 | Docker Swarm support required (i.e., alternatives without this, like Podman, are insufficient) |
-| Docker Compose     | \>=1.29.2; also <2.0.x                      |                 [See issue #133](https://github.com/NOAA-OWP/DMOD/issues/133)                  |
-| Bash               | \>=3.2.57                                   |                                                                                                |
-| OpenSSL / LibreSSL | \>=3.0.0 / \>=2.8.3                         |                                                                                                |
+| Dependency              | Constraints         |                                                                  Notes                                                                   |
+|-------------------------|:--------------------|:----------------------------------------------------------------------------------------------------------------------------------------:|
+| Docker Engine           | \>=20.10.16         |                      Docker Swarm support required (i.e., alternatives without this, like Podman, are insufficient)                      |
+| Docker Compose          | \>=2.0.x            |               [See issue #133](https://github.com/NOAA-OWP/DMOD/issues/133); _deployx_ plugin now required as noted below                |
+| _deployx_ Docker plugin | \>=0.0.1            | Available [here](https://github.com/aaraney/deployx).  Results in some transitive dependencies not explicitly enumerated here (e.g., Go) |
+| Bash                    | \>=3.2.57           |                                                                                                                                          |
+| OpenSSL / LibreSSL      | \>=3.0.0 / \>=2.8.3 |                                                                                                                                          |
 
 ## Development Dependencies
 | Dependency                                | Constraints                                 |                       Notes                        |

--- a/docker/main/docker-deploy.yml
+++ b/docker/main/docker-deploy.yml
@@ -234,7 +234,7 @@ volumes:
 
 secrets:
   myredis_pass:
-    file: ../secrets/myredis_password.txt
+    file: ${DOCKER_REDIS_SECRET_FILE:?Variable DOCKER_REDIS_SECRET_FILE unset in env; no path to myredis password Docker secrete file}
   # Have to create these here from the same backing files, since the stack prefix causes issue with sharing secrets
   # across stacks
   object_store_exec_user_passwd:

--- a/scripts/control_stack.sh
+++ b/scripts/control_stack.sh
@@ -307,7 +307,7 @@ exec_requested_actions()
 
     if [ -n "${DO_DEPLOY_ACTION:-}" ]; then
         echo "Deploying stack ${STACK_NAME:?}"
-        docker_dev_deploy_stack_from_compose_using_env "${DOCKER_DEPLOY_CONFIG:?}" "${STACK_NAME:?}" "$(whoami)"
+        docker_dev_deploy_stack_from_compose_using_env "${DOCKER_DEPLOY_CONFIG:?}" "${STACK_NAME:?}"
         bail_if_action_failed $? deploy
     fi
 }


### PR DESCRIPTION
Updates the DMOD stacks control scripts to make use of the [_deployx_](https://github.com/aaraney/deployx) Docker API plugin.  This will allow use of configs that take advantage of variable substitution without using the old (soon to be unavailable) workaround (see #133).

Documentation pages providing information on installing dependencies have also been updated.