### PR TITLE
Fix SchedulerRequestResponse's data field access

### DIFF
--- a/python/lib/communication/dmod/communication/scheduler_request.py
+++ b/python/lib/communication/dmod/communication/scheduler_request.py
@@ -204,7 +204,7 @@ class SchedulerRequestResponse(Response):
         """
         if self.data is None:
             return None
-        return self.data.get("output_data_id")
+        return self.data.output_data_id
 
     @classmethod
     def factory_init_from_deserialized_json(cls, json_obj: dict) -> "SchedulerRequestResponse":


### PR DESCRIPTION
Prior to #331, `dmod.communication.Response`'s `data` field was an `Optional[dict]`. Post #331, `dmod.communication.Response`'s `data` field is an `Optional[dmod.core.Serializable]`. This PR updates _how_ the `SchedulerRequestResponse` type accesses its `data` field.

related to #352

It is likely that there are bugs in the codebase with the same origin. I will open an issue to track finding and resolving any lingering instances where `data` is being accessed like a dictionary.