### PR TITLE
Fix for double logging

### DIFF
--- a/python/gui/maas_experiment/logging.py
+++ b/python/gui/maas_experiment/logging.py
@@ -449,10 +449,6 @@ DEFAULT_LOGGING_CONFIGURATION = {
             'datefmt': os.environ.get("LOG_DATEFMT", application_values.COMMON_DATETIME_FORMAT)
         },
     },
-    'root': {
-        'handlers': [f'{DEFAULT_LOGGER_NAME}_Handler', 'stdout'],
-        'level': get_log_level()
-    },
     'handlers': {
         f'{DEFAULT_LOGGER_NAME}_Handler': create_handler_configuration(
             level=get_log_level(),

--- a/python/services/evaluationservice/dmod/evaluationservice/service/logging.py
+++ b/python/services/evaluationservice/dmod/evaluationservice/service/logging.py
@@ -449,10 +449,6 @@ DEFAULT_LOGGING_CONFIGURATION = {
             'datefmt': os.environ.get("LOG_DATEFMT", application_values.COMMON_DATETIME_FORMAT)
         },
     },
-    'root': {
-        'handlers': [f'{DEFAULT_LOGGER_NAME}_Handler', 'stdout'],
-        'level': get_log_level()
-    },
     'handlers': {
         f'{DEFAULT_LOGGER_NAME}_Handler': create_handler_configuration(
             level=get_log_level(),


### PR DESCRIPTION
I found an issue where using the application specific loggers would log twice - once for the application logger and once through root. Removing the root configuration in the default setup limits the logging so that it is only logged once.