### PR TITLE
Improve creation of ContinuousRestriction subtypes

### DIFF
--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -389,8 +389,7 @@ class ContinuousRestriction(Serializable):
 
         field_serializers = {
             "begin": _serialize_datetime,
-            "end": _serialize_datetime,
-            "subclass": lambda value: value.__name__
+            "end": _serialize_datetime
             }
 
     def __eq__(self, o: object) -> bool:

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -347,7 +347,7 @@ class ContinuousRestriction(Serializable):
             if subclass_str == subclass.__name__:
                 return super().__new__(subclass)
 
-        msg = f"{subclass_str!r} is not supclass of {cls.__name__!r}. Initializing {cls.__name__!r}."
+        msg = f"{subclass_str!r} is not subclass of {cls.__name__!r}. Initializing {cls.__name__!r}."
         warnings.warn(msg, RuntimeWarning)
         return super().__new__(cls)
 

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -853,7 +853,7 @@ class TimeRange(ContinuousRestriction):
     """
     Encapsulated representation of a time range.
     """
-    variable: StandardDatasetIndex = Field(StandardDatasetIndex.TIME, const=True)
+    variable: StandardDatasetIndex = Field(StandardDatasetIndex.TIME.name, const=True)
 
     @classmethod
     def parse_from_string(cls, as_string: str, dt_format: Optional[str] = None, dt_str_length: int = 19) -> 'TimeRange':


### PR DESCRIPTION
Overload `__new__` to simplify and improve creation of `ContinuousRestriction` subtypes. This also solves an issue where `ContinuousRestriction`'s json schema could not be dumped. No change in behavior.