### PR TITLE
Add data format value for t-route configs

### DIFF
--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -169,7 +169,7 @@ class DataFormat(PydanticEnum):
     different partitioning schemes, making it useful to keep it as a thing unto itself.
     """
 
-    T_ROUTE_CONFIG = (13, {StandardDatasetIndex.HYDROFABRIC_ID: None}, None, False)
+    T_ROUTE_CONFIG = (13, {StandardDatasetIndex.DATA_ID: None, StandardDatasetIndex.HYDROFABRIC_ID: None}, None, False)
     """ Format for t-route application configuration. """
 
     @classmethod

--- a/python/lib/core/dmod/core/meta_data.py
+++ b/python/lib/core/dmod/core/meta_data.py
@@ -169,6 +169,9 @@ class DataFormat(PydanticEnum):
     different partitioning schemes, making it useful to keep it as a thing unto itself.
     """
 
+    T_ROUTE_CONFIG = (13, {StandardDatasetIndex.HYDROFABRIC_ID: None}, None, False)
+    """ Format for t-route application configuration. """
+
     @classmethod
     def can_format_fulfill(cls, needed: 'DataFormat', alternate: 'DataFormat') -> bool:
         """


### PR DESCRIPTION
Creating a simple `DataFormat` value for the format of _t-route_ config data.