### PR TITLE
transform fields accept any callable type

### DIFF
--- a/python/lib/core/dmod/test/test_serializable_field_serializers.py
+++ b/python/lib/core/dmod/test/test_serializable_field_serializers.py
@@ -277,3 +277,13 @@ class TestFieldSerializerConfigOption(unittest.TestCase):
 
         with self.assertRaises(RuntimeError):
             o.dict()
+
+    def test_fixes_380(self):
+        class Model(Serializable):
+            field: int
+
+            class Config(Serializable.Config):
+                field_serializers = {"field": str}
+
+        m = Model(field=42)
+        self.assertDictEqual(m.dict(), {"field": "42"})


### PR DESCRIPTION
Fixes #380.

## Changes

- fix bug #380. `_transform_fields` now accept any callable type.