### PR TITLE
Add missing Dataset field serializers

### DIFF
--- a/python/lib/core/dmod/core/dataset.py
+++ b/python/lib/core/dmod/core/dataset.py
@@ -117,7 +117,19 @@ class Dataset(Serializable):
         # TODO: in future deprecate setting properties unless through a setter method
         validate_assignment = True
         arbitrary_types_allowed = True
-        field_serializers = {"uuid": lambda f: str(f)}
+
+        def _serialize_datetime(self: "Dataset", value: Optional[datetime]) -> Optional[str]:
+            if isinstance(value, datetime):
+                return value.strftime(self._SERIAL_DATETIME_STR_FORMAT)
+            return value
+
+        field_serializers = {
+            "uuid": str,
+            "manager_uuid": lambda f: None if f is None else str(f),
+            "expires": _serialize_datetime,
+            "created_on": _serialize_datetime,
+            "last_updated": _serialize_datetime,
+        }
 
     def __hash__(self):
         members = [

--- a/python/lib/core/dmod/core/dataset.py
+++ b/python/lib/core/dmod/core/dataset.py
@@ -124,7 +124,7 @@ class Dataset(Serializable):
             return value
 
         field_serializers = {
-            "uuid": str,
+            "uuid": lambda f: None if f is None else str(f),
             "manager_uuid": lambda f: None if f is None else str(f),
             "expires": _serialize_datetime,
             "created_on": _serialize_datetime,

--- a/python/lib/core/dmod/test/test_dataset.py
+++ b/python/lib/core/dmod/test/test_dataset.py
@@ -1,4 +1,5 @@
 import unittest
+from uuid import uuid4
 from ..core.dataset import Dataset, DatasetType
 from ..core.meta_data import DataCategory, DataDomain, DataFormat, DiscreteRestriction, TimeRange
 from datetime import datetime, timedelta
@@ -114,4 +115,35 @@ class TestDataset(unittest.TestCase):
 
         self.assertEqual(expected_data_dict, data_dict)
 
+    def test_fixes_377(self):
+        """Verify fields with field_serializers are serialized to correct type."""
 
+        some_id = uuid4()
+        now = datetime.now()
+        m = Dataset(
+            name="fix-377",
+            data_category=DataCategory.CONFIG,
+            data_domain=DataDomain(
+                data_format=DataFormat.BMI_CONFIG,
+                discrete=[
+                    DiscreteRestriction(
+                        variable=StandardDatasetIndex.DATA_ID, values=["42"]
+                    )
+                ],
+            ),
+            access_location="test_fixes_377",
+            uuid=some_id,
+            is_read_only=True,
+            created_on=now,
+            expires=now,
+            last_updated=now,
+            dataset_type=DatasetType.OBJECT_STORE,
+            manager_uuid=some_id,
+        )
+        serialized = m.dict()
+
+        self.assertTrue(isinstance(serialized["uuid"], str))
+        self.assertTrue(isinstance(serialized["manager_uuid"], str))
+        self.assertTrue(isinstance(serialized["created_on"], str))
+        self.assertTrue(isinstance(serialized["expires"], str))
+        self.assertTrue(isinstance(serialized["last_updated"], str))

--- a/python/lib/core/dmod/test/test_dataset.py
+++ b/python/lib/core/dmod/test/test_dataset.py
@@ -1,13 +1,12 @@
 import unittest
 from uuid import uuid4
 from ..core.dataset import Dataset, DatasetType
-from ..core.meta_data import DataCategory, DataDomain, DataFormat, DiscreteRestriction, TimeRange
+from ..core.meta_data import DataCategory, DataDomain, DataFormat, DiscreteRestriction, TimeRange, StandardDatasetIndex
 from datetime import datetime, timedelta
 from typing import Optional, Union
 
 
 class TestDataset(unittest.TestCase):
-
     @classmethod
     def generate_testing_time_range(cls, begin: Union[str, datetime], length: Optional[timedelta] = None,
                                     pattern: Optional[str] = None) -> TimeRange:
@@ -68,7 +67,7 @@ class TestDataset(unittest.TestCase):
                                       "uuid": str(self.example_datasets[i].uuid),
                                       "access_location": 'location_{}'.format(i),
                                       "is_read_only": False,
-                                      "created_on": self._created_on, # NOTE: breaking change
+                                      "created_on": datetime.strftime(self._created_on, Dataset._SERIAL_DATETIME_STR_FORMAT),
                                       })
 
     def test_factory_init_from_deserialized_json_0_a(self):


### PR DESCRIPTION
fixes #377

## Changes

- Add missing `dmod.core.dataset.Dataset` field serializers (fixes #377).