### PR TITLE
Upload data to dataset using readable object

### DIFF
--- a/python/lib/client/dmod/client/_reader.py
+++ b/python/lib/client/dmod/client/_reader.py
@@ -1,4 +1,6 @@
-from typing import Protocol, Union
+import asyncio
+from functools import partial
+from typing import Optional, Protocol, Union
 
 
 class Reader(Protocol):
@@ -25,3 +27,17 @@ class AsyncReader(Protocol):
 
     async def read(self, size: Union[int, None] = ...) -> bytes:
         ...
+
+
+class AsyncReadWrapper:
+    """
+    Wrapper object for treating a sync reader as an async reader.
+    """
+
+    def __init__(self, reader: Reader) -> None:
+        self._reader = reader
+        self._loop = asyncio.get_running_loop()
+
+    async def read(self, size: Optional[int] = None) -> bytes:
+        fn = partial(self._reader.read, size)
+        return await self._loop.run_in_executor(None, fn)

--- a/python/lib/client/dmod/client/_reader.py
+++ b/python/lib/client/dmod/client/_reader.py
@@ -1,0 +1,27 @@
+from typing import Protocol, Union
+
+
+class Reader(Protocol):
+    """Reader interface type.
+
+    Example:
+    ```
+    def upload(data: Reader) -> None:
+        ...
+
+    with open("some_file.txt", "rb") as fp:
+        upload(fp)
+    ```
+    """
+
+    def read(self, size: Union[int, None] = ...) -> bytes:
+        ...
+
+
+class AsyncReader(Protocol):
+    """
+    Async Reader interface type.
+    """
+
+    async def read(self, size: Union[int, None] = ...) -> bytes:
+        ...

--- a/python/lib/client/dmod/client/request_clients.py
+++ b/python/lib/client/dmod/client/request_clients.py
@@ -13,6 +13,8 @@ from typing import List, Optional, Tuple, Type, Union
 import json
 import websockets
 
+from ._reader import AsyncReader
+
 #import logging
 #logger = logging.getLogger("gui_log")
 
@@ -153,6 +155,28 @@ class DatasetClient(ABC):
             The name of the dataset.
         paths : List[Path]
             List of one or more paths of files to upload or directories containing files to upload.
+
+        Returns
+        -------
+        bool
+            Whether uploading was successful
+        """
+        pass
+
+    @abstractmethod
+    async def upload_data_to_dataset(self, dataset_name: str, item_name: str, data: AsyncReader) -> bool:
+        """
+        Upload data to existing dataset.
+
+        Parameters
+        ----------
+        dataset_name : str
+            The name of the dataset.
+        item_name : str
+            The name of the dataset item.
+        data : AsyncReader
+            Object with `async def read(self, size: int | None) -> bytes` method. Object will be
+            cooperatively polled until it return EOF.
 
         Returns
         -------

--- a/python/lib/client/dmod/client/request_clients.py
+++ b/python/lib/client/dmod/client/request_clients.py
@@ -280,6 +280,10 @@ class DatasetInternalClient(DatasetClient, DataServiceClient):
         # TODO: *********************************************
         raise NotImplementedError('Function upload_to_dataset not implemented')
 
+    async def upload_data_to_dataset(self, dataset_name: str, item_name: str, data: AsyncReader) -> bool:
+        # TODO
+        raise NotImplementedError('Function upload_data_to_dataset not implemented')
+
 
 class DatasetExternalClient(DatasetClient,
                             ExternalRequestClient[MaaSDatasetManagementMessage, MaaSDatasetManagementResponse]):

--- a/python/lib/client/dmod/test/test_dataset_client.py
+++ b/python/lib/client/dmod/test/test_dataset_client.py
@@ -1,5 +1,6 @@
 import unittest
 from ..client.request_clients import DataCategory, DatasetClient, DatasetManagementResponse, MaaSDatasetManagementResponse
+from ..client._reader import AsyncReader
 from pathlib import Path
 from typing import List, Optional
 
@@ -33,6 +34,10 @@ class SimpleMockDatasetClient(DatasetClient):
         return []
 
     async def upload_to_dataset(self, dataset_name: str, paths: List[Path]) -> bool:
+        """ Mock implementation, always returning ``False``. """
+        return False
+
+    async def upload_data_to_dataset(self, dataset_name: str, item_name: str, data: AsyncReader) -> bool:
         """ Mock implementation, always returning ``False``. """
         return False
 


### PR DESCRIPTION
Adds an async `upload_data_to_dataset` method to dataset clients that polls an async readable object that implements `async def read(self, size: Optional[int] = None) -> bytes`. This adds flexibility, so it is not required to treat to-be uploaded items as files.

## Additions

- Adds an async `upload_data_to_dataset` method to dataset clients that polls an async readable object that implements `async def read(self, size: Optional[int] = None) -> bytes`.

## Notes

- Not sure the correct _internal_ equivalent type to `MaaSDatasetManagementMessage`

## Todos

- unit tests
- implement `upload_data_to_dataset` for `DatasetInternalClient`