### PR TITLE
Standardize Evaluation ID generation

### DIFF
--- a/python/gui/MaaS/cbv/evaluation.py
+++ b/python/gui/MaaS/cbv/evaluation.py
@@ -34,9 +34,13 @@ class EvaluationListing(View):
         return render(request, template_name=self.template, context=context)
 
 
-def _generate_evaluation_id() -> str:
-    current_date = datetime.now()
-    date_representation = current_date.strftime("%m-%d_%H.%M")
+def _generate_evaluation_id(generation_date: datetime = None) -> str:
+    current_date = generation_date or datetime.now()
+
+    if current_date.tzinfo is None:
+        current_date = current_date.astimezone()
+
+    date_representation = current_date.strftime("%m-%d_%H.%M%z")
     evaluation_id = f"manual_evaluation_at_{date_representation}"
     return evaluation_id
 


### PR DESCRIPTION
closes #215

Stems from [a comment in a PR](https://github.com/NOAA-OWP/DMOD/pull/184#discussion_r1014246624) about how example generated ids are created when rendering the editing screen for evaluations.