### PR TITLE
Fix ngen worker entrypoint handling of CPU count

### DIFF
--- a/docker/main/ngen/entrypoint.sh
+++ b/docker/main/ngen/entrypoint.sh
@@ -175,7 +175,7 @@ if [ ${MPI_NODE_COUNT:?} -gt 1 ]; then
 # If using only a single node, then we must check how many CPUs the host has
 elif [ $(echo "${MPI_HOST_STRING}" | sed 's/,//' | awk -F: '{print $2}') -gt 1 ] 2>/dev/null ; then
     check_for_dataset_dir "${PARTITION_DATASET_DIR:?No partition dataset directory defined}"
-# Also sanity the check host string format and CPU count extraction, ensuring we didn't produce a false negative above
+# Also sanity check the host string format and CPU count extraction, ensuring we didn't produce a false negative above
 elif [ $(echo "${MPI_HOST_STRING}" | sed 's/,//' | awk -F: '{print $2}') -ne 1 ] 2>/dev/null ; then
     echo "Error: failed to extract integer CPU count for first host of MPI host string '${MPI_HOST_STRING}'" 2>&1
     exit 1

--- a/docker/main/ngen/entrypoint.sh
+++ b/docker/main/ngen/entrypoint.sh
@@ -185,7 +185,7 @@ cd ${OUTPUT_DATASET_DIR}
 
 if [ "${WORKER_INDEX}" = "0" ]; then
     if [ "$(whoami)" = "${MPI_USER}" ]; then
-        if [ ${MPI_NODE_COUNT:-1} -gt 1 ]; then
+        if [ -n "${PARTITION_DATASET_DIR:-}" ]; then
             exec_main_worker_ngen_run
         else
             exec_serial_ngen_run


### PR DESCRIPTION
Fixing entrypoint script to properly account for hosts with more than a single CPU.  This includes the logic for supplying args to `mpirun`,  dealing with (or ignoring) partition config dataset details, and branching execution for parallel versus serial jobs.