### PR TITLE
Update ngen Docker image to build t-route master branch

### DIFF
--- a/docker/main/docker-build.yml
+++ b/docker/main/docker-build.yml
@@ -70,8 +70,8 @@ services:
         REPO_URL: ${NGEN_REPO_URL?No NGen repo url configured}
         BRANCH: ${NGEN_BRANCH?No NGen branch configured}
         COMMIT: ${NGEN_COMMIT}
-        TROUTE_REPO_URL: ${TROUTE_REPO_URL?No t-route repo url configured}
-        TROUTE_BRANCH: ${TROUTE_BRANCH?No t-route branch configured}
+        TROUTE_REPO_URL: ${TROUTE_REPO_URL:-https://github.com/NOAA-OWP/t-route}
+        TROUTE_BRANCH: ${TROUTE_BRANCH:-master}
         TROUTE_COMMIT: ${TROUTE_COMMIT}
         BUILD_PARALLEL_JOBS: ${NGEN_BUILD_PARALLEL_JOBS:-2}
         DOCKER_INTERNAL_REGISTRY: ${DOCKER_INTERNAL_REGISTRY:?}
@@ -105,8 +105,8 @@ services:
         REPO_URL: ${NGEN_REPO_URL?No NGen repo url configured}
         NGEN_CAL_BRANCH: ${NGEN_CAL_BRANCH:-master}
         NGEN_CAL_COMMIT: ${NGEN_CAL_COMMIT}
-        TROUTE_REPO_URL: ${TROUTE_REPO_URL?No t-route repo url configured}
-        TROUTE_BRANCH: ${TROUTE_BRANCH?No t-route branch configured}
+        TROUTE_REPO_URL: ${TROUTE_REPO_URL:-https://github.com/NOAA-OWP/t-route}
+        TROUTE_BRANCH: ${TROUTE_BRANCH:-master}
         TROUTE_COMMIT: ${TROUTE_COMMIT}
         BUILD_PARALLEL_JOBS: ${NGEN_BUILD_PARALLEL_JOBS:-2}
         DOCKER_INTERNAL_REGISTRY: ${DOCKER_INTERNAL_REGISTRY:?}

--- a/docker/main/docker-build.yml
+++ b/docker/main/docker-build.yml
@@ -103,6 +103,8 @@ services:
       target: ngen_cal_worker
       args:
         REPO_URL: ${NGEN_REPO_URL?No NGen repo url configured}
+        BRANCH: ${NGEN_BRANCH?No NGen branch configured}
+        COMMIT: ${NGEN_COMMIT}
         NGEN_CAL_BRANCH: ${NGEN_CAL_BRANCH:-master}
         NGEN_CAL_COMMIT: ${NGEN_CAL_COMMIT}
         TROUTE_REPO_URL: ${TROUTE_REPO_URL:-https://github.com/NOAA-OWP/t-route}

--- a/docker/main/ngen/.boost_local_copying.md
+++ b/docker/main/ngen/.boost_local_copying.md
@@ -1,0 +1,5 @@
+# About 
+
+This is essentially a dummy file used by the Dockerfile for the _ngen_ (and related) Docker images to enable copying a local Boost tar file from the local context when one is there without breaking the build when one isn't.  See the _download_boost_ build stage in [Dockerfile](./Dockerfile).
+
+This file generally shouldn't change.  If it is changed, any build layers within the Docker build cache that rely on _download_boost_ (in particular the layers that actually compile the ngen executable) will be invalidated and rebuilt.  

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -145,9 +145,15 @@ FROM rockylinux:8.5 AS download_boost
 # Redeclaring inside this stage to get default from before first FROM
 ARG BOOST_VERSION
 
-RUN curl -L -o boost_${BOOST_VERSION//./_}.tar.bz2 https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//./_}.tar.bz2/download \
-    && mkdir /boost \
-    && mv boost_${BOOST_VERSION//./_}.tar.bz2 /boost/.
+# Copy of entrypoint.sh here is just to avoid failure if there is no boost_*.tar.* present,,,
+COPY entrypoint.sh boost_*.tar.* ${WORKDIR}
+
+RUN mkdir ${WORKDIR}/boost \
+    && if compgen -G "./boost_*.tar.*" > /dev/null; then \
+        mv ${WORKDIR}/boost_*.tar.* ${WORKDIR}/boost/boost_tarball.blob ; \
+    else \
+        curl -L -o ${WORKDIR}/boost/boost_tarball.blob https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//./_}.tar.bz2/download ; \
+    fi
 
 ################################################################################################################
 ################################################################################################################
@@ -360,9 +366,9 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && echo "alias python='python3'" >> /etc/profile \
     # Also set up boost here, since we copied the download but only just installed bzip2 to work with it \
     && cd ${BOOST_ROOT} \
-    && tar -xjf boost_${BOOST_VERSION//./_}.tar.bz2 \
-    && rm boost_${BOOST_VERSION//./_}.tar.bz2 \
-    # Set the regular user as the owner
+    && tar -xf boost_tarball.blob \
+    && rm boost_tarball.blob \
+    # Set the regular user as the owner \
     && chown -R ${USER}:${USER} ${BOOST_ROOT} \
     && rm -rf /tmp/ngen-deps
 

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -321,20 +321,20 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && tar xfz mpich-${MPICH_VERSION}.tar.gz  \
     && cd mpich-${MPICH_VERSION} \
     && ./configure ${MPICH_CONFIGURE_OPTIONS} \
-    && make -j $(nproc) ${MPICH_MAKE_OPTIONS} && make install \
+    && make -j ${BUILD_PARALLEL_JOBS} ${MPICH_MAKE_OPTIONS} && make install \
     ##### Build and install HDF5 \
     && cd /tmp/ngen-deps \
     && tar -xzf hdf5-${HD5_VERSION}.tar.gz \
     && cd hdf5-${HD5_VERSION} \
     && ./configure --enable-parallel --prefix=/usr \
-    && make -j $(nproc) && make install \
+    && make -j ${BUILD_PARALLEL_JOBS} && make install \
     ##### Build and install NetCDF C \
     && cd /tmp/ngen-deps \
     && mkdir netcdf \
     && tar -xzf netcdf-${NETCDF_C_VERSION}.tar.gz -C netcdf --strip 1 \
     && cd netcdf \
     && LIBS=curl && ./configure --prefix=/usr \
-    && make -j $(nproc) && make install \
+    && make -j ${BUILD_PARALLEL_JOBS} && make install \
     # TODO: if we run into any problem, might need to reactivate this \
     #&& make check \
     ##### Build and install NetCDF Fortran \
@@ -352,7 +352,7 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && mkdir netcdf-cxx4/build \
     && cd netcdf-cxx4/build \
     && cmake .. \
-    && make \
+    && make -j ${BUILD_PARALLEL_JOBS} \
     # TODO: if we run into any problem, might need to reactivate this \
     # && ctest \
     && make install \

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -25,7 +25,7 @@ ARG COMMIT
 ARG WORKDIR=/ngen
 
 ARG TROUTE_REPO_URL=https://github.com/NOAA-OWP/t-route.git
-ARG TROUTE_BRANCH=ngen
+ARG TROUTE_BRANCH=master
 ARG TROUTE_COMMIT
 
 ARG NGEN_CAL_BRANCH=master
@@ -263,7 +263,7 @@ ARG ROCKY_NGEN_DEPS_REQUIRED
 USER root
 RUN dnf update -y && dnf install -y ${ROCKY_NGEN_DEPS_REQUIRED} \
     && pip3 install --upgrade pip \
-    && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then pip3 install numpy; fi
+    && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then pip3 install numpy; fi 
 USER ${USER}
 
 ################################################################################################################
@@ -442,21 +442,18 @@ USER ${USER}
 RUN cd ${WORKDIR}/t-route \
     && mkdir wheels \
     && pip3 install -r ./requirements.txt \
-    && pip3 install wheel deprecated dask \
+    && pip3 install wheel deprecated dask pyarrow geopandas \
     && cd ${WORKDIR}/t-route \
-    && cd ./src/python_routing_v02 \
     && ./compiler.sh \
+    && cd ./src/troute-network \
     && python3 setup.py bdist_wheel \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
-    && cd ../python_framework_v02 \
+    && cd ../troute-routing \
     && python3 setup.py bdist_wheel \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
-    && cd ../nwm_routing \
+    && cd ../troute-nwm \
     && python3 setup.py bdist_wheel \
-    && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
-    && cd ../ngen_routing \
-    && python3 setup.py bdist_wheel \
-    && cp dist/*.whl ${WORKDIR}/t-route/wheels/
+    && cp dist/*.whl ${WORKDIR}/t-route/wheels/ 
 
 USER root
 RUN rm /usr/bin/python

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -495,8 +495,12 @@ ENV BOOST_ROOT=${WORKDIR}/boost
 
 USER root
 RUN if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
-        chgrp -R ${USER} /usr/local/lib*/python3.* \
-        && chmod -R g+sw /usr/local/lib*/python3.* ; \
+        chgrp -R ${USER} /usr/local/lib*/python3.* ; \
+        chmod -R g+sw /usr/local/lib*/python3.* ; \
+    fi \
+    && if [ "${NGEN_ROUTING_ACTIVE}" == "ON" ]; then \
+        # These packages install command line tools, which try to go in /usr/local/bin \
+        pip3 install pyarrow pyproj fiona; \
     fi
 USER ${USER}
 
@@ -504,7 +508,9 @@ RUN cd ${WORKDIR}/ngen \
     && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
         pip3 install -r extern/test_bmi_py/requirements.txt; \
         if [ "${NGEN_ROUTING_ACTIVE}" == "ON" ] ; then \
-            pip3 install /tmp/t-route-wheels/*.whl; pip3 install -r /tmp/t-route-requirements.txt; \
+            pip3 install /tmp/t-route-wheels/*.whl; \
+            pip3 install -r /tmp/t-route-requirements.txt; \
+            pip3 install deprecated geopandas ; \
             fi; \
         fi \
     &&  if [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ]; then \

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -145,14 +145,16 @@ FROM rockylinux:8.5 AS download_boost
 # Redeclaring inside this stage to get default from before first FROM
 ARG BOOST_VERSION
 
-# Copy of entrypoint.sh here is just to avoid failure if there is no boost_*.tar.* present,,,
-COPY entrypoint.sh boost_*.tar.* ${WORKDIR}
+# Copy this file here is just to avoid failure if there is no boost_*.tar.* present.
+# Use essentially a dummy file that won't change (unless someone does that deliberately to trigger a full rebuild), as
+#   any change to this file will cause anything and and build layer/stage that uses boost to be fully rebuilt.
+COPY .boost_local_copying.md boost_*.tar.* ${WORKDIR}
 
-RUN mkdir ${WORKDIR}/boost \
-    && if compgen -G "./boost_*.tar.*" > /dev/null; then \
-        mv ${WORKDIR}/boost_*.tar.* ${WORKDIR}/boost/boost_tarball.blob ; \
+RUN mkdir /boost \
+    && if compgen -G "${WORKDIR}/boost_${BOOST_VERSION//./_}.tar.*" > /dev/null; then \
+        mv ${WORKDIR}/boost_${BOOST_VERSION//./_}.tar.* /boost/boost_tarball.blob ; \
     else \
-        curl -L -o ${WORKDIR}/boost/boost_tarball.blob https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//./_}.tar.bz2/download ; \
+        curl -L -o /boost/boost_tarball.blob https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION}/boost_${BOOST_VERSION//./_}.tar.bz2/download ; \
     fi
 
 ################################################################################################################

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -344,7 +344,7 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && cd netcdf-fortran \
     && export NCDIR=/usr NFDIR=/usr \
     && LD_LIBRARY_PATH=/usr/lib CPPFLAGS=-I/usr/include LDFLAGS=-L/usr/lib ./configure --prefix=/usr \
-    && make -j $(nproc) && make install \
+    && make -j ${BUILD_PARALLEL_JOBS} && make install \
     ##### Build and install NetCDF C++ \
     && cd /tmp/ngen-deps \
     && mkdir netcdf-cxx4 \
@@ -358,7 +358,7 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && make install \
     # Install required python dependency packages with Pip \
     && pip3 install numpy pandas pyyaml bmipy Cython blosc2==${BLOSC2_VERSION:-2.0.0} netCDF4 wheel packaging \
-    && env HDF5_DIR=/usr pip3 install --no-build-isolation tables \
+    && env HDF5_DIR=/usr pip3 install --install-option="\'--jobs=${BUILD_PARALLEL_JOBS} \'"  --no-build-isolation tables \
     # Make aliases for convenience \
     && alias pip='pip3' \
     && echo "alias pip='pip3'" >> /etc/profile \

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -262,7 +262,7 @@ ARG ROCKY_NGEN_DEPS_REQUIRED
 # Note that this includes numpy, which is needed for Python BMI support, regardless of BMI module 
 USER root
 RUN dnf update -y && dnf install -y ${ROCKY_NGEN_DEPS_REQUIRED} \
-    && pip3 install --upgrade pip \
+    && pip3 install "pip>=23.0,<23.1" wheel packaging \
     && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then pip3 install numpy; fi 
 USER ${USER}
 
@@ -443,13 +443,14 @@ RUN cd ${WORKDIR}/t-route \
     && mkdir wheels \
     && pip3 install -r ./requirements.txt \
     && pip3 install wheel deprecated dask pyarrow geopandas \
+    && export FC=gfortran \
     && cd ${WORKDIR}/t-route \
     && ./compiler.sh \
     && cd ./src/troute-network \
-    && python3 setup.py bdist_wheel \
+    && python3 setup.py --use-cython bdist_wheel \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
     && cd ../troute-routing \
-    && python3 setup.py bdist_wheel \
+    && python3 setup.py --use-cython bdist_wheel \
     && cp dist/*.whl ${WORKDIR}/t-route/wheels/ \
     && cd ../troute-nwm \
     && python3 setup.py bdist_wheel \

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -33,7 +33,7 @@ ARG NGEN_CAL_COMMIT
 
 #### Default arguments for required dependencies needed during various build stages
 # The Rocky-Linux-based "base" stage, rocky-base
-ARG ROCKY_BASE_REQUIRED="sudo openssh openssh-server bash git"
+ARG ROCKY_BASE_REQUIRED="sudo openssh openssh-server bash git which"
 # The Rocky-Linux-based "ngen-deps" stage, rocky-ngen-deps
 # TODO: later look at separating build and run images again, and install static lib netcdf packages in run images
 #ARG ROCKY_NGEN_DEPS_REQUIRED="mpich mpich-devel sudo gcc gcc-c++ make cmake tar git gcc-gfortran libgfortran \
@@ -261,11 +261,14 @@ FROM rocky-base as rocky-ngen-packaged-deps
 
 ARG ROCKY_NGEN_DEPS_REQUIRED
 
+# TODO: later, go back and change all pip3/python3 to just pip/python (but leave for now to limit scope)
 # Note that this includes numpy, which is needed for Python BMI support, regardless of BMI module 
 USER root
-RUN dnf update -y && dnf install -y ${ROCKY_NGEN_DEPS_REQUIRED} \
-    && pip3 install "pip>=23.0,<23.1" wheel packaging \
-    && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then pip3 install numpy; fi 
+RUN dnf update -y && dnf install -y ${ROCKY_NGEN_DEPS_REQUIRED} && dnf clean -y all \
+    && ln -s $(which python3) $(which python3 | sed 's/python3/python/') \
+    && ln -s $(which pip3) $(which pip3 | sed 's/pip3/pip/') \
+    && pip install --no-cache-dir "pip>=23.0,<23.1" wheel packaging \
+    && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then pip install --no-cache-dir numpy; fi
 USER ${USER}
 
 ################################################################################################################

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -361,14 +361,6 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     # TODO: if we run into any problem, might need to reactivate this \
     # && ctest \
     && make install \
-    # Install required python dependency packages with Pip \
-    && pip3 install numpy pandas pyyaml bmipy Cython blosc2==${BLOSC2_VERSION:-2.0.0} netCDF4 wheel packaging \
-    && env HDF5_DIR=/usr pip3 install --install-option="\'--jobs=${BUILD_PARALLEL_JOBS} \'"  --no-build-isolation tables \
-    # Make aliases for convenience \
-    && alias pip='pip3' \
-    && echo "alias pip='pip3'" >> /etc/profile \
-    && alias python='python3'  \
-    && echo "alias python='python3'" >> /etc/profile \
     # Also set up boost here, since we copied the download but only just installed bzip2 to work with it \
     && cd ${BOOST_ROOT} \
     && tar -xf boost_tarball.blob \
@@ -376,6 +368,10 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     # Set the regular user as the owner \
     && chown -R ${USER}:${USER} ${BOOST_ROOT} \
     && rm -rf /tmp/ngen-deps
+
+# Install required Python packages for troute build/run that needed one or more of the source dependencies
+RUN pip install --no-cache-dir numpy pandas pyyaml bmipy Cython blosc2==${BLOSC2_VERSION:-2.0.0} netCDF4 wheel packaging \
+    && env HDF5_DIR=/usr pip install --no-cache-dir --no-build-isolation tables
 
 ENV PATH=${PATH}:/usr/lib64/mpich/bin
 ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/lib:/usr/local/lib64
@@ -438,10 +434,6 @@ ARG COMMIT
 ARG BUILD_PARALLEL_JOBS
 
 COPY --chown=${USER} --from=rocky_init_troute_repo ${WORKDIR}/t-route ${WORKDIR}/t-route
-
-USER root
-RUN cp -s /usr/bin/python3 /usr/bin/python
-USER ${USER}
 
 #    && python(){ /usr/bin/python3 \$@; } && export -f python \
 RUN cd ${WORKDIR}/t-route \

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -495,6 +495,14 @@ COPY --chown=${USER} --from=rocky_build_troute ${WORKDIR}/t-route/wheels /tmp/t-
 COPY --chown=${USER} --from=rocky_build_troute ${WORKDIR}/t-route/requirements.txt /tmp/t-route-requirements.txt
 ENV BOOST_ROOT=${WORKDIR}/boost
 
+USER root
+# Note that while nothing is installed in /usr/local/lib/python3, pip apparently checks here to see if it has permissions before installing in the global site.
+RUN if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
+        chgrp -R ${USER} /usr/local/lib*/python3.* \
+        && chmod -R g+sw /usr/local/lib*/python3.* ; \
+    fi
+USER ${USER}
+
 RUN cd ${WORKDIR}/ngen \
     && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
         pip3 install -r extern/test_bmi_py/requirements.txt; \

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -494,7 +494,6 @@ COPY --chown=${USER} --from=rocky_build_troute ${WORKDIR}/t-route/requirements.t
 ENV BOOST_ROOT=${WORKDIR}/boost
 
 USER root
-# Note that while nothing is installed in /usr/local/lib/python3, pip apparently checks here to see if it has permissions before installing in the global site.
 RUN if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
         chgrp -R ${USER} /usr/local/lib*/python3.* \
         && chmod -R g+sw /usr/local/lib*/python3.* ; \


### PR DESCRIPTION
Switch to building/installing t-route master instead of t-route ngen branch.  Very similar to changes from #318, but with some modifications based on initial review and evolution of the repo since.

## Additions

- Several small build system improvements including: 
  - using `${BUILD_PARALLEL_JOBS}` instead of `$(nproc)`
  - an improved way to optionally pass a pre-downloaded boost tarball to the image creation process, without reducing Docker build cache utilization
  - remove of the requirement for t-route repo/branch values to be explicitly provided in the .env file

## Removals

- Does not work out of the box to use legacy t-route (e.g. ngen branch), which might limit capability with some older hydrofabric datasets.

## Changes

- Now compiles and builds master t-route by default (instead of ngen branch)
- Several Python elements are now installed in the global (root) site. This enables use-cases where a user other than mpi(1000) is used, e.g. using docker run --user=$(uid -u), so now the routing modules are available to that user
  - These changes were carried over from #318; they were tested there but have not been subsequently retest as of this writing

