### PR TITLE
Fix and optimize ngen-related image builds

### DIFF
--- a/docker/main/docker-build.yml
+++ b/docker/main/docker-build.yml
@@ -59,7 +59,17 @@ services:
       context: ./ngen
       target: rocky_ngen_build_testing
       args:
+        REPO_URL: ${NGEN_REPO_URL?No NGen repo url configured}
+        BRANCH: ${NGEN_BRANCH?No NGen branch configured}
+        COMMIT: ${NGEN_COMMIT}
+        TROUTE_REPO_URL: ${TROUTE_REPO_URL:-https://github.com/NOAA-OWP/t-route}
+        TROUTE_BRANCH: ${TROUTE_BRANCH:-master}
+        TROUTE_COMMIT: ${TROUTE_COMMIT}
+        BUILD_PARALLEL_JOBS: ${NGEN_BUILD_PARALLEL_JOBS:-2}
+        REFRESH_BEFORE_BUILD: ${NGEN_REFRESH_BEFORE_BUILD:-true}
         DOCKER_INTERNAL_REGISTRY: ${DOCKER_INTERNAL_REGISTRY:?}
+    depends_on:
+      - ngen-deps
 
   ngen:
     image: ${DOCKER_INTERNAL_REGISTRY:?}/ngen:${NGEN_VERSION:-latest}
@@ -74,6 +84,7 @@ services:
         TROUTE_BRANCH: ${TROUTE_BRANCH:-master}
         TROUTE_COMMIT: ${TROUTE_COMMIT}
         BUILD_PARALLEL_JOBS: ${NGEN_BUILD_PARALLEL_JOBS:-2}
+        REFRESH_BEFORE_BUILD: ${NGEN_REFRESH_BEFORE_BUILD:-true}
         DOCKER_INTERNAL_REGISTRY: ${DOCKER_INTERNAL_REGISTRY:?}
     depends_on:
       - ngen-deps
@@ -91,6 +102,7 @@ services:
         BRANCH: ${NGEN_BRANCH?No NGen branch configured}
         COMMIT: ${NGEN_COMMIT}
         BUILD_PARALLEL_JOBS: ${NGEN_BUILD_PARALLEL_JOBS:-2}
+        REFRESH_BEFORE_BUILD: ${NGEN_REFRESH_BEFORE_BUILD:-true}
         DOCKER_INTERNAL_REGISTRY: ${DOCKER_INTERNAL_REGISTRY:?}
         PARTITIONER_EXECUTABLE: ${PARTITIONER_EXECUTABLE:-partitionGenerator}
     depends_on:
@@ -111,6 +123,7 @@ services:
         TROUTE_BRANCH: ${TROUTE_BRANCH:-master}
         TROUTE_COMMIT: ${TROUTE_COMMIT}
         BUILD_PARALLEL_JOBS: ${NGEN_BUILD_PARALLEL_JOBS:-2}
+        REFRESH_BEFORE_BUILD: ${NGEN_REFRESH_BEFORE_BUILD:-true}
         DOCKER_INTERNAL_REGISTRY: ${DOCKER_INTERNAL_REGISTRY:?}
     depends_on:
       - ngen

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -22,6 +22,8 @@ ARG DATASET_DIRECTORIES="config forcing hydrofabric observation output"
 ARG REPO_URL=https://github.com/NOAA-OWP/ngen.git
 ARG BRANCH=master
 ARG COMMIT
+# Helper flag to, if "true" AND if COMMIT is not set, `git pull --ff-only` within the repo dir just before building ngen
+ARG REFRESH_BEFORE_BUILD=true
 ARG WORKDIR=/ngen
 
 ARG TROUTE_REPO_URL=https://github.com/NOAA-OWP/t-route.git
@@ -365,7 +367,7 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && make install \
     # Also set up boost here, since we copied the download but only just installed bzip2 to work with it \
     && cd ${BOOST_ROOT} \
-    && tar -xf boost_tarball.blob \
+    && tar -xf boost_tarball.blob --strip 1 \
     && rm boost_tarball.blob \
     # Set the regular user as the owner \
     && chown -R ${USER}:${USER} ${BOOST_ROOT} \
@@ -430,9 +432,9 @@ RUN cd ${WORKDIR} \
 ##### Create intermediate Docker build stage for building t-route in Rocky Linux environment
 FROM rocky-ngen-deps as rocky_build_troute
 
-ARG REPO_URL
-ARG BRANCH
-ARG COMMIT
+ARG TROUTE_REPO_URL
+ARG TROUTE_BRANCH
+ARG TROUTE_COMMIT
 ARG BUILD_PARALLEL_JOBS
 
 COPY --chown=${USER} --from=rocky_init_troute_repo ${WORKDIR}/t-route ${WORKDIR}/t-route
@@ -467,6 +469,7 @@ FROM rocky-ngen-deps as rocky_build_ngen
 ARG REPO_URL
 ARG BRANCH
 ARG COMMIT
+ARG REFRESH_BEFORE_BUILD
 ARG BUILD_PARALLEL_JOBS
 
 ARG NGEN_BUILD_CONFIG_TYPE
@@ -499,17 +502,26 @@ RUN if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
     fi \
     && if [ "${NGEN_ROUTING_ACTIVE}" == "ON" ]; then \
         # These packages install command line tools, which try to go in /usr/local/bin \
-        pip3 install pyarrow pyproj fiona; \
+        pip3 install --no-cache-dir pyarrow pyproj fiona; \
     fi
 USER ${USER}
 
 RUN cd ${WORKDIR}/ngen \
-    && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
-        pip3 install -r extern/test_bmi_py/requirements.txt; \
-        if [ "${NGEN_ROUTING_ACTIVE}" == "ON" ] ; then \
-            pip3 install /tmp/t-route-wheels/*.whl; \
-            pip3 install -r /tmp/t-route-requirements.txt; \
-            pip3 install deprecated geopandas ; \
+    &&  if [ -z "${COMMIT:-}" ]; then \
+            if [ "${REFRESH_BEFORE_BUILD:-}" = "true" ] ; then  \
+                git pull --ff-only ; \
+                git submodule update --init --depth 1 test/googletest ; \
+                git submodule update --init --recursive --depth 1 ; \
+            fi ; \
+        fi \
+    # C++ functionality isn't separate, so always build the test_bmi_cpp shared lib \
+    && ./build_sub extern/test_bmi_cpp \
+    &&  if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
+            pip3 install --no-cache-dir -r extern/test_bmi_py/requirements.txt; \
+            if [ "${NGEN_ROUTING_ACTIVE}" == "ON" ] ; then \
+                pip3 install --no-cache-dir /tmp/t-route-wheels/*.whl; \
+                pip3 install --no-cache-dir -r /tmp/t-route-requirements.txt; \
+                pip3 install --no-cache-dir deprecated geopandas ; \
             fi; \
         fi \
     &&  if [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ]; then \
@@ -564,8 +576,7 @@ RUN cd ${WORKDIR}/ngen \
         #Run the tests, if they fail, the image build fails \
         && cmake --build $BUILD_DIR --target test_unit -j ${BUILD_PARALLEL_JOBS} \
         && $BUILD_DIR/test/test_unit \
-        # C++ functionality isn't separate, so always build the test_bmi_cpp shared lib (also needed for test_bmi_multi) \
-        && ./build_sub extern/test_bmi_cpp \
+        # C++ functionality isn't separate, so always build and run the test_bmi_cpp testing target \
         && cmake --build $BUILD_DIR --target test_bmi_cpp \
         && $BUILD_DIR/test/test_bmi_cpp \
         # For the external language BMI integrations, conditionally build the test packages/libraries and run tests \
@@ -586,7 +597,7 @@ RUN cd ${WORKDIR}/ngen \
         &&  if [ "${NGEN_ACTIVATE_C}" == "ON" ] && [ "${NGEN_ACTIVATE_FORTRAN}" == "ON" ] && [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then \
                 cmake --build $BUILD_DIR --target test_bmi_multi; \
                 $BUILD_DIR/test/test_bmi_multi; \
-            fi \
+            fi ; \
     done \
     && find cmake_build* -type f -name "*" ! \( -name "*.so" -o -name "ngen" -o -name "partitionGenerator" \) -exec rm {} +
 
@@ -608,6 +619,8 @@ WORKDIR ${WORKDIR}/ngen
 FROM rocky-ngen-deps as partitioner_image
 
 ARG BUILD_PARALLEL_JOBS
+ARG COMMIT
+ARG REFRESH_BEFORE_BUILD
 ARG NGEN_ACTIVATE_C
 ARG NGEN_ACTIVATE_FORTRAN
 ARG NGEN_ACTIVATE_PYTHON
@@ -621,6 +634,11 @@ COPY --chown=${USER} --from=rocky_init_repo ${WORKDIR}/ngen ${WORKDIR}/ngen
 ENV BOOST_ROOT=${WORKDIR}/boost
 
 RUN cd ${WORKDIR}/ngen \
+    &&  if [ "x$COMMIT" = "x" ]; then \
+            if [ "${REFRESH_BEFORE_BUILD:-}" = "true" ] ; then  \
+                git pull --ff-only ; \
+            fi ; \
+        if \
     && if [ -z "${PARTITIONER_EXECUTABLE:-}" ]; then echo "Error: target/executable name not set" 2>&1 ; exit 1; fi \
     && cmake -B cmake_build -S . \
                -DMPI_ACTIVE:BOOL=OFF \
@@ -668,7 +686,7 @@ RUN rm -rf ${BOOST_ROOT} && echo "export PATH=${PATH}" >> /etc/profile \
     && sed -i "s/PermitRootLogin yes/PermitRootLogin no/g" /etc/ssh/sshd_config \
     && sed -i "s/#ClientAliveInterval.*/ClientAliveInterval 60/" /etc/ssh/sshd_config \
     && sed -i "s/#ClientAliveCountMax.*/ClientAliveCountMax 5/" /etc/ssh/sshd_config \
-    && rm /var/run/nologin  \
+    && if [ -f /var/run/nologin ]; then rm /var/run/nologin ; fi  \
     && mkdir -p /dmod/datasets && chown ${USER} /dmod/datasets \
     && mkdir -p /dmod/shared_libs && chown ${USER} /dmod/shared_libs \
     && mkdir -p /dmod/bin && chown ${USER} /dmod/bin 

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -43,7 +43,7 @@ ARG ROCKY_BASE_REQUIRED="sudo openssh openssh-server bash git which"
 #    bzip2 expat expat-devel flex bison udunits2 udunits2-devel"
 
 ARG ROCKY_NGEN_DEPS_REQUIRED="sudo gcc gcc-c++ make cmake tar git gcc-gfortran libgfortran \
-    python39 python39-devel python39-pip \
+    python3 python3-devel python3-pip \
     bzip2 expat expat-devel flex bison udunits2 udunits2-devel zlib-devel"
 # TODO: removed texinfo from list because it couldn't be found; make sure this doesn't lead to issues
 
@@ -86,7 +86,7 @@ ARG BUILD_SLOTH="true"
 ################################################################################################################
 ################################################################################################################
 ##### Create intermediate Docker build stage for Rocky-Linux-based "base"
-FROM rockylinux:8.5 as rocky-base
+FROM rockylinux:9.1 as rocky-base
 
 ARG USER=mpi
 ENV USER=${USER} USER_HOME=/home/${USER}
@@ -96,9 +96,10 @@ ARG ROCKY_BASE_REQUIRED
 
 RUN dnf update -y \
     && dnf install -y 'dnf-command(config-manager)' \
-    && dnf config-manager --set-enabled powertools \
+    && dnf config-manager --set-enabled crb \
     && dnf install -y epel-release \
     && dnf -y install ${ROCKY_BASE_REQUIRED} \
+    && dnf -y clean all \
     # Note that adduser -p expects an encrypted/hashed password, so it will ignore a simple password \
     && adduser -p 'ignored' ${USER} \
     && echo "${USER}   ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
@@ -140,7 +141,7 @@ USER ${USER}
 ################################################################################################################
 ################################################################################################################
 ##### Create intermediate Docker build stage for downloading Boost
-FROM rockylinux:8.5 AS download_boost
+FROM rockylinux:9.1 AS download_boost
 
 # Redeclaring inside this stage to get default from before first FROM
 ARG BOOST_VERSION
@@ -160,7 +161,7 @@ RUN mkdir /boost \
 ################################################################################################################
 ################################################################################################################
 ##### Create intermediate Docker build stage for downloading MPICH
-FROM rockylinux:8.5 AS download_mpich
+FROM rockylinux:9.1 AS download_mpich
 
 # Redeclaring inside this stage to get default from before first FROM
 ARG MPICH_VERSION
@@ -171,7 +172,7 @@ RUN curl -o /tmp/mpich-${MPICH_VERSION}.tar.gz https://www.mpich.org/static/down
 ################################################################################################################
 ################################################################################################################
 ##### Create intermediate Docker build stage for downloading MPICH
-FROM rockylinux:8.5 AS download_hd5
+FROM rockylinux:9.1 AS download_hd5
 
 # Redeclaring inside this stage to get default from before first FROM
 ARG HD5_VERSION
@@ -266,7 +267,6 @@ ARG ROCKY_NGEN_DEPS_REQUIRED
 USER root
 RUN dnf update -y && dnf install -y ${ROCKY_NGEN_DEPS_REQUIRED} && dnf clean -y all \
     && ln -s $(which python3) $(which python3 | sed 's/python3/python/') \
-    && ln -s $(which pip3) $(which pip3 | sed 's/pip3/pip/') \
     && pip install --no-cache-dir "pip>=23.0,<23.1" wheel packaging \
     && if [ "${NGEN_ACTIVATE_PYTHON}" == "ON" ]; then pip install --no-cache-dir numpy; fi
 USER ${USER}
@@ -592,9 +592,12 @@ RUN cd ${WORKDIR}/ngen \
 ################################################################################################################
 ##### A build stage for testing using the ngen-build-test image
 FROM rocky_build_ngen as rocky_ngen_build_testing
+#FROM ${DOCKER_INTERNAL_REGISTRY}/ngen-deps:latest as rocky_ngen_build_testing
 
 #COPY --chown=${USER} --from=rocky_init_repo ${WORKDIR}/ngen ${WORKDIR}/ngen
 #ENV BOOST_ROOT=${WORKDIR}/boost
+#COPY --chown=${USER} --from=rocky_build_troute ${WORKDIR}/t-route/wheels /tmp/t-route-wheels
+#COPY --chown=${USER} --from=rocky_build_troute ${WORKDIR}/t-route/requirements.txt /tmp/t-route-requirements.txt
 WORKDIR ${WORKDIR}/ngen
 
 ################################################################################################################

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -638,7 +638,7 @@ RUN cd ${WORKDIR}/ngen \
             if [ "${REFRESH_BEFORE_BUILD:-}" = "true" ] ; then  \
                 git pull --ff-only ; \
             fi ; \
-        if \
+        fi \
     && if [ -z "${PARTITIONER_EXECUTABLE:-}" ]; then echo "Error: target/executable name not set" 2>&1 ; exit 1; fi \
     && cmake -B cmake_build -S . \
                -DMPI_ACTIVE:BOOL=OFF \

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -729,6 +729,9 @@ ARG NGEN_CAL_COMMIT
 # Overwrite the ngen entrypoint script from the parent stage, which is already set up with ENTRYPOINT
 COPY --chown=${USER:?} ngen_cal_entrypoint.sh ${WORKDIR:?}/entrypoint.sh
 
+USER root
 # Try NGEN_CAL_COMMIT, if not set or empty, use NGEN_CAL_BRANCH
-RUN pip install "git+https://github.com/noaa-owp/ngen-cal@${NGEN_CAL_COMMIT:-${NGEN_CAL_BRANCH}}#egg=ngen_cal&subdirectory=python/ngen_cal" \
-    && chmod +x ${WORKDIR}/entrypoint.sh
+RUN pip install --no-cache-dir "git+https://github.com/noaa-owp/ngen-cal@${NGEN_CAL_COMMIT:-${NGEN_CAL_BRANCH}}#egg=ngen_cal&subdirectory=python/ngen_cal"
+
+USER ${USER}
+RUN chmod +x ${WORKDIR}/entrypoint.sh

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -47,8 +47,9 @@ ARG ROCKY_NGEN_DEPS_REQUIRED="sudo gcc gcc-c++ make cmake tar git gcc-gfortran l
     bzip2 expat expat-devel flex bison udunits2 udunits2-devel zlib-devel"
 # TODO: removed texinfo from list because it couldn't be found; make sure this doesn't lead to issues
 
-ARG BOOST_VERSION=1.72.0
-ARG MPICH_VERSION="3.2"
+ARG BOOST_VERSION=1.82.0
+#mpich 3.2 doesn't work well gfortran 11 it seems, an alignment error crops up, but 3.3.2 seems to work...
+ARG MPICH_VERSION="3.3.2"
 ARG MIN_PYTHON="3.8.0"
 ARG MIN_NUMPY="1.18.0"
 ARG BLOSC2_VERSION
@@ -325,7 +326,8 @@ RUN echo "export HYDRA_HOST_FILE=${HYDRA_HOST_FILE}" >> /etc/profile \
     && cd /tmp/ngen-deps \
     && tar xfz mpich-${MPICH_VERSION}.tar.gz  \
     && cd mpich-${MPICH_VERSION} \
-    && ./configure ${MPICH_CONFIGURE_OPTIONS} \
+    # mpich3 and gfortran > 10 don't get along...https://gcc.gnu.org/bugzilla/show_bug.cgi?id=91731 \
+    && FFLAGS="-w -fallow-argument-mismatch -O2"  ./configure ${MPICH_CONFIGURE_OPTIONS} \
     && make -j ${BUILD_PARALLEL_JOBS} ${MPICH_MAKE_OPTIONS} && make install \
     ##### Build and install HDF5 \
     && cd /tmp/ngen-deps \


### PR DESCRIPTION
Address a few problems and add some optimizations to the ngen worker, calibration worker, partitioner Docker images:

- Move to RockyLinux 9.1 to get default support for GCC 11
  - Needed in particular to work around some current issues in the framework
- Update version of mpich to play nicely with Fortran from GCC 11
- Correct Boost dependency version to be recent enough for current framework requirements (now 1.82.0)
- Modify build stages that build ngen to (typically) do a `git pull` just before to ensure working on most recent commit for a branch
- Ensuring Docker stack config, which controls the overall build process, establishes the same set of `ARG` values for related images (`ngen`, `ngen-calibration`, etc.) so that things behave as expected/consistently and the build cache is used effectively
- Ensure use of `pip`'s `--no-cache-dir` option to optimize storage space a bit