### PR TITLE
Fix request service handling of eval service

### DIFF
--- a/python/services/requestservice/dmod/requestservice/__main__.py
+++ b/python/services/requestservice/dmod/requestservice/__main__.py
@@ -69,16 +69,16 @@ def _handle_args():
                         default=None)
     parser.add_argument('--evaluation-service-host',
                         help='Set the appropriate hostname for the evaluation service to connect with',
-                        dest='data_service_host',
+                        dest='evaluation_service_host',
                         default='localhost')
     parser.add_argument('--evaluation-service-port',
                         help='Set the appropriate port value for the evaluation service to connect with',
-                        dest='data_service_port',
+                        dest='evaluation_service_port',
                         default='3014')
     parser.add_argument('--evaluation-service-ssl-dir',
                         help='Set the ssl directory for evaluation service certs, '
                              'if not the same as for the request handler',
-                        dest='data_service_ssl_dir',
+                        dest='evaluation_service_ssl_dir',
                         default=None)
     parser.add_argument('--pycharm-remote-debug',
                         help='Activate Pycharm remote debugging support',
@@ -161,7 +161,8 @@ def main():
                              partitioner_port=args.partitioner_service_port,
                              partitioner_ssl_dir=args.partitioner_service_ssl_dir,
                              evaluation_service_host=args.evaluation_service_host,
-                             evaluation_service_port=args.evaluation_service_port)
+                             evaluation_service_port=args.evaluation_service_port,
+                             evaluation_service_ssl_dir=args.evaluation_service_ssl_dir)
     handler.run()
 
 


### PR DESCRIPTION
Deals with some issues in how the request service deals with evaluation service connection details, as the latter doesn't actually exist in the `main` deployment stack yet.  These are currently keeping the request service from starting successfully.

- Fix request service main package arg handling, which was overwriting args related to data service connections with eval service values
- Within _RequestService_, wrap creation of evaluation request handler in `try` block, falling back to a `None` value if something is raised 
- Raise a _RuntimeError_ in _RequestService.listener()_ if an evaluation request comes in but the evaluation request handler attribute is `None`.
