### PR TITLE
Add third Docker network for internal service communication in main stack 

### DIFF
--- a/docker/main/docker-deploy.yml
+++ b/docker/main/docker-deploy.yml
@@ -5,7 +5,7 @@ services:
     image: ${DOCKER_INTERNAL_REGISTRY:?Missing DOCKER_INTERNAL_REGISTRY value (see 'Private Docker Registry ' section in example.env)}/scheduler-service
     networks:
       - mpi-net
-      - requests-net
+      - main-internal-net
     ports:
         - "3013:3013"
     volumes:
@@ -42,7 +42,7 @@ services:
     ports:
       - "6379:6379"
     networks:
-      requests-net:
+      main-internal-net:
         aliases:
           - ${DOCKER_REDIS_SERVICE_ALIAS:-redis}
     entrypoint: "/entrypoint.sh"
@@ -64,6 +64,7 @@ services:
     networks:
       #- mpi-net
       - requests-net
+      - main-internal-net
     deploy:
       #mode: global
       placement:
@@ -113,7 +114,7 @@ services:
   subset-service:
     image: ${DOCKER_INTERNAL_REGISTRY:?Missing DOCKER_INTERNAL_REGISTRY value (see 'Private Docker Registry ' section in example.env)}/subset-service
     networks:
-      - requests-net
+      - main-internal-net
     ports:
       - ${DOCKER_SUBSET_API_PORT:-5001}:${DOCKER_SUBSET_CONTAINER_PORT:-5001}
     volumes:
@@ -144,7 +145,7 @@ services:
     hostname: data-service
     networks:
       - mpi-net
-      - requests-net
+      - main-internal-net
     deploy:
       placement:
         constraints:
@@ -186,7 +187,7 @@ services:
     image: "${DOCKER_INTERNAL_REGISTRY:?Missing DOCKER_INTERNAL_REGISTRY value (see 'Private Docker Registry ' section in example.env)}/partitioner-service:latest"
     networks:
       #- mpi-net
-      - requests-net
+      - main-internal-net
     ports:
       - "${DOCKER_PARTITIONER_SERVICE_CONTAINER_PORT:-3014}:${DOCKER_PARTITIONER_SERVICE_CONTAINER_PORT:-3014}"
     secrets:
@@ -220,6 +221,9 @@ networks:
     mpi-net:
         external: true
         name: ${DOCKER_MPI_NET_NAME}
+    main-internal-net:
+      external: true
+      name: ${DOCKER_MAIN_INTERNAL_NET_NAME}
     requests-net:
         external: true
         name: ${DOCKER_REQUESTS_NET_NAME}

--- a/example.env
+++ b/example.env
@@ -227,6 +227,21 @@ DOCKER_REQUESTS_NET_SUBNET=10.0.1.0/27
 DOCKER_REQUESTS_NET_GATEWAY=10.0.1.1
 
 ########################################################################
+## Docker "main_internal" overlay network settings                    ##
+########################################################################
+## Settings for another network for use by the "main" stack as the    ##
+## primary medium for communication between stack services.  It       ##
+## generally should not be attached to items containers or services   ##
+## outside of the "main" stack.                                       ##
+##                                                                    ##
+## This network will also be created automatically if it does not     ##
+## already exist by the stack control script.                         ##
+########################################################################
+DOCKER_MAIN_INTERNAL_NET_NAME=main-internal-net
+DOCKER_MAIN_INTERNAL_NET_SUBNET=10.0.1.32/27
+DOCKER_MAIN_INTERNAL_NET_GATEWAY=10.0.1.33
+
+########################################################################
 ## Private Docker Registry                                            ##
 ########################################################################
 ## Configuration for private registry to which and from which custom  ##

--- a/scripts/control_stack.sh
+++ b/scripts/control_stack.sh
@@ -280,6 +280,11 @@ exec_requested_actions()
                 ${DOCKER_REQUESTS_NET_SUBNET:?} \
                 ${DOCKER_REQUESTS_NET_GATEWAY:?} \
                 ${DOCKER_REQUESTS_NET_DRIVER:-overlay}
+        # Finally the main-internal-net
+        docker_dev_init_swarm_network ${DOCKER_MAIN_INTERNAL_NET_NAME:=main-internal-net} \
+                ${DOCKER_MAIN_INTERNAL_NET_SUBNET:?} \
+                ${DOCKER_MAIN_INTERNAL_NET_GATEWAY:?} \
+                ${DOCKER_MAIN_INTERNAL_NET_DRIVER:-overlay}
     fi
 
     if [ -n "${DO_CHECK_ACTION:-}" ]; then


### PR DESCRIPTION
Adding and applying a third Docker network to configuration of _main_ stack, intended for internal communication.  Updating scripts to automatically create this network in the same fashion as others, and updating example env config file with details on how applicable values are configured.

This closes #415.