### PR TITLE
Fixing Startup Issues with Several Services

### DIFF
--- a/python/lib/modeldata/dmod/modeldata/hydrofabric/hydrofabric.py
+++ b/python/lib/modeldata/dmod/modeldata/hydrofabric/hydrofabric.py
@@ -391,7 +391,7 @@ class HydrofabricFilesManager(ABC):
         self._hydrofabric_initializers: List[Callable[[Any, ...], Hydrofabric]] = []
         self._hydrofabric_uids: List[Optional[str]] = []
         self.find_hydrofabrics()
-        super(HydrofabricFilesManager, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def find_hydrofabrics(self, recheck: bool = False):
         """

--- a/python/services/partitionerservice/dmod/partitionerservice/__main__.py
+++ b/python/services/partitionerservice/dmod/partitionerservice/__main__.py
@@ -10,6 +10,7 @@ from . import name as package_name
 from .service import ServiceManager
 from dmod.scheduler.job import DefaultJobUtilFactory
 from dmod.externalrequests.maas_request_handlers import DataServiceClient
+from dmod.communication import WebSocketClient
 from pathlib import Path
 from socket import gethostname
 
@@ -38,7 +39,7 @@ def _handle_args():
     parser.add_argument('--ssl-dir',
                         help='Change the base directory when using SSL certificate and key files with default names',
                         dest='ssl_dir',
-                        default='/ssl/partitionerservice')
+                        default='/ssl/partitioner-service')
     parser.add_argument('--cert',
                         help='Specify path for a particular SSL certificate file to use',
                         dest='cert_path',
@@ -154,8 +155,9 @@ def main():
     job_util = DefaultJobUtilFactory.factory_create(redis_host=args.redis_host, redis_port=args.redis_port,
                                                     redis_pass=redis_pass)
 
-    data_service_url = DataServiceClient.build_endpoint_uri(host=args.data_service_host, port=args.data_service_port)
-    data_client = DataServiceClient(endpoint_uri=data_service_url, ssl_directory=Path(args.data_service_ssl_dir))
+    data_client = DataServiceClient(transport_client=WebSocketClient(endpoint_host=args.data_service_host,
+                                                                     endpoint_port=args.data_service_port,
+                                                                     capath=args.data_service_ssl_dir))
 
     service = ServiceManager(port=args.listen_port, listen_host=args.listen_host, ssl_dir=Path(args.ssl_dir),
                              cert_pem=args.cert_path, priv_key_pem=args.key_path, image_name=image, job_util=job_util,

--- a/python/services/requestservice/dmod/requestservice/service.py
+++ b/python/services/requestservice/dmod/requestservice/service.py
@@ -13,7 +13,7 @@ from websockets import WebSocketServerProtocol
 from dmod.access import DummyAuthUtil, RedisBackendSessionManager
 from dmod.communication import AbstractInitRequest, InvalidMessageResponse, MessageEventType, NGENRequest, NWMRequest, \
     NgenCalibrationRequest, PartitionRequest, WebSocketSessionsInterface, SessionInitMessage, SchedulerClient, \
-    UnsupportedMessageTypeResponse
+    UnsupportedMessageTypeResponse, WebSocketClient
 from dmod.communication.dataset_management_message import MaaSDatasetManagementMessage
 from dmod.externalrequests import AuthHandler, DatasetRequestHandler, ModelExecRequestHandler, \
     NgenCalibrationRequestHandler, PartitionRequestHandler, EvaluationRequestHandler
@@ -111,9 +111,9 @@ class RequestService(WebSocketSessionsInterface):
         # FIXME: implement real authorizer
         self.authorizer = self.authenticator
 
-        scheduler_url = "wss://{}:{}".format(self.scheduler_host, self.scheduler_port)
-
-        self._scheduler_client = SchedulerClient(scheduler_url, self.scheduler_client_ssl_dir)
+        self._scheduler_client = SchedulerClient(transport_client=WebSocketClient(endpoint_host=self.scheduler_host,
+                                                                                  endpoint_port=self.scheduler_port,
+                                                                                  capath=self.scheduler_client_ssl_dir))
         """SchedulerClient: Client for interacting with scheduler, which also is a context manager for connections."""
 
         self._auth_handler: AuthHandler = AuthHandler(session_manager=self._session_manager,


### PR DESCRIPTION
Primarily fixing issues with partitioner and request services, due to service client attributes (i.e., clients for *other* services) not having been updated to the new design using transport clients.

Also, making some changes to `minio_init.sh` to improve (but not fix; that'll have to wait for #459) how it deals with certain situations when there could be API incompatibility between the MinIO client (which the script uses) and the MinIO service. 