### PR TITLE
Update gh actions unit test

### DIFF
--- a/.github/workflows/testing_and_validation.yml
+++ b/.github/workflows/testing_and_validation.yml
@@ -104,6 +104,13 @@ jobs:
           cp -a ssl/local/*.pem ssl/requests/.
           cp -a ssl/local/*.pem ssl/scheduler/.
 
+      - name: Echo dependency versions
+        run: |
+          . dmod_venv/bin/activate
+          python3 -m pip freeze
+          deactivate
+        timeout-minutes: 1
+
       - name: Run Tests
         run: ./scripts/run_tests.sh --venv dmod_venv -v -d -srv
         timeout-minutes: 1

--- a/.github/workflows/testing_and_validation.yml
+++ b/.github/workflows/testing_and_validation.yml
@@ -15,15 +15,20 @@ jobs:
   test_unit_ubuntu_latest:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11']
+
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - name: Install python3-venv
-        run: sudo apt-get install -y python3-venv
-        timeout-minutes: 5
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Cache Python Venv
         id: cache-python-venv

--- a/.github/workflows/testing_and_validation.yml
+++ b/.github/workflows/testing_and_validation.yml
@@ -91,7 +91,6 @@ jobs:
           key: dmod-ssl-setup
 
       # Set up the SSL directory
-      # TODO: use more project-generic choice for email address for generated certs
       - name: Setup SSL
         if: steps.cache-ssl-setup.outputs.cache-hit != 'true'
         run: |
@@ -100,7 +99,7 @@ jobs:
           mkdir ssl/requestservice
           mkdir ssl/requests
           mkdir ssl/scheduler
-          ./scripts/gen_cert.sh -d ssl/local -email robert.bartel@noaa.gov
+          ./scripts/gen_cert.sh -d ssl/local -email dmod_gh_action@fake.gov
           cp -a ssl/local/*.pem ssl/requestservice/.
           cp -a ssl/local/*.pem ssl/requests/.
           cp -a ssl/local/*.pem ssl/scheduler/.

--- a/.github/workflows/testing_and_validation.yml
+++ b/.github/workflows/testing_and_validation.yml
@@ -5,9 +5,9 @@ name: Testing and Validation
 # Controls when the action will run.
 on:
   push:
-    branches: [ master, dev, notreal ]
+    branches: [ master, dev ]
   pull_request:
-    branches: [ master, dev, notreal ]
+    branches: [ master, dev ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
- Add build python matrix. Tests now run on python `3.8`, `3.9`, `3.10`, and `3.11`.
- Add step to echo dependency versions. This is useful for debugging purposes.
- Fix TLS certs email todo. Certs now use phony `dmod_gh_action@fake.gov` email address.

closes #457 
