### PR TITLE
bump min required version of to `aiohttp~=3.8`

### DIFF
--- a/python/lib/modeldata/setup.py
+++ b/python/lib/modeldata/setup.py
@@ -28,7 +28,7 @@ setup(
         "dmod-communication>=0.4.2",
         "dmod-core>=0.9.0",
         "minio",
-        "aiohttp<=3.7.4",
+        "aiohttp~=3.8",
         "shapely>=2.0.0",
         "hypy@git+https://github.com/noaa-owp/hypy@master#egg=hypy&subdirectory=python",
         "gitpython",

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ numpy
 scikit-learn
 minio
 uri
-aiohttp==3.8.5
+aiohttp~=3.8
 channels
 channels-redis
 Pint


### PR DESCRIPTION
Bump min required version of to `aiohttp~=3.8`. This should remove the warning in the dependency graph.