### PR TITLE
Fix `dmod.scheduler` test warnings

### DIFF
--- a/python/lib/scheduler/dmod/test/test_JobImpl.py
+++ b/python/lib/scheduler/dmod/test/test_JobImpl.py
@@ -55,7 +55,7 @@ class TestJobImpl(unittest.TestCase):
 
         self.assertNotEqual(job.job_id, uuid_as_str)
 
-        job.job_id = uuid_val
+        job.set_job_id(uuid_val)
 
         self.assertEqual(job.job_id, uuid_as_str)
 
@@ -68,7 +68,7 @@ class TestJobImpl(unittest.TestCase):
         job = self._example_jobs[example_index]
         initial_last_updated = job.last_updated
 
-        job.job_id = uuid_val
+        job.set_job_id(uuid_val)
 
         self.assertLess(initial_last_updated, job.last_updated)
 
@@ -81,7 +81,7 @@ class TestJobImpl(unittest.TestCase):
 
         self.assertNotEqual(job.job_id, uuid_as_str)
 
-        job.job_id = uuid_as_str
+        job.set_job_id(uuid_as_str)
 
         self.assertEqual(job.job_id, uuid_as_str)
 
@@ -93,7 +93,7 @@ class TestJobImpl(unittest.TestCase):
         job = self._example_jobs[example_index]
         initial_last_updated = job.last_updated
 
-        job.job_id = uuid_as_str
+        job.set_job_id(uuid_as_str)
 
         self.assertLess(initial_last_updated, job.last_updated)
 
@@ -142,7 +142,7 @@ class TestJobImpl(unittest.TestCase):
         job = self._example_jobs[example_index_job]
 
         self.assertIsNone(job.allocations)
-        job.allocations = allocations
+        job.set_allocations(allocations)
         self.assertIsNotNone(job.allocations)
 
     # Test that allocation setter works with tuple
@@ -155,7 +155,7 @@ class TestJobImpl(unittest.TestCase):
         job = self._example_jobs[example_index_job]
 
         self.assertIsNone(job.allocations)
-        job.allocations = allocations
+        job.set_allocations(allocations)
         self.assertIsNotNone(job.allocations)
 
     # Test that allocation setter works correctly with list
@@ -166,7 +166,7 @@ class TestJobImpl(unittest.TestCase):
         allocation = self._resource_allocations[example_index_allocation]
         allocations = [allocation]
         job = self._example_jobs[example_index_job]
-        job.allocations = allocations
+        job.set_allocations(allocations)
         self.assertEqual(len(allocations), len(job.allocations))
         for i in range(len(allocations)):
             self.assertEqual(allocations[i], job.allocations[i])
@@ -179,7 +179,7 @@ class TestJobImpl(unittest.TestCase):
         allocation = self._resource_allocations[example_index_allocation]
         allocations = (allocation,)
         job = self._example_jobs[example_index_job]
-        job.allocations = allocations
+        job.set_allocations(allocations)
         self.assertEqual(len(allocations), len(job.allocations))
         for i in range(len(allocations)):
             self.assertEqual(allocations[i], job.allocations[i])
@@ -193,7 +193,7 @@ class TestJobImpl(unittest.TestCase):
         allocations = [allocation]
         job = self._example_jobs[example_index_job]
         initial_last_updated = job.last_updated
-        job.allocations = allocations
+        job.set_allocations(allocations)
         self.assertLess(initial_last_updated, job.last_updated)
 
     # Test that allocation setter updates last_updated correctly with tuple
@@ -206,7 +206,7 @@ class TestJobImpl(unittest.TestCase):
         job = self._example_jobs[example_index_job]
         initial_last_updated = job.last_updated
 
-        job.allocations = allocations
+        job.set_allocations(allocations)
         self.assertLess(initial_last_updated, job.last_updated)
 
     # TODO: add tests for rest of setters that should update last_updated property

--- a/python/lib/scheduler/dmod/test/test_scheduler.py
+++ b/python/lib/scheduler/dmod/test/test_scheduler.py
@@ -68,7 +68,7 @@ class TestLauncher(unittest.TestCase):
                                           allocation_paradigm='SINGLE_NODE')
         ex_job = RequestedJob(sch_req)
         alloc = ResourceAllocation('1', 'hostname1', cpu_count, mem_size)
-        ex_job.allocations = [alloc]
+        ex_job.set_allocations([alloc])
         self._example_jobs.append(ex_job)
 
         # Example 2 - with two node allocated with 4 cpus
@@ -96,7 +96,7 @@ class TestLauncher(unittest.TestCase):
         allocs = []
         allocs.append(ResourceAllocation('1', 'hostname1', 2, int(mem_size/2)))
         allocs.append(ResourceAllocation('2', 'hostname2', 2, int(mem_size/2)))
-        ex_job.allocations = allocs
+        ex_job.set_allocations(allocs)
         self._example_jobs.append(ex_job)
 
 

--- a/python/services/monitorservice/dmod/test/test_monitor_service.py
+++ b/python/services/monitorservice/dmod/test/test_monitor_service.py
@@ -131,9 +131,9 @@ class TestMonitorService(unittest.TestCase):
         self._connect_metadata_examples.append('{"purpose": "PROMPT", "additional_metadata": false}')
         self._connect_metadata_examples.append('{"purpose": "CONNECT", "additional_metadata": true}')
 
-        self._jobs[0].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION)
-        self._jobs[1].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_SCHEDULING)
-        self._jobs[2].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.SCHEDULED)
+        self._jobs[0].set_status(JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_ALLOCATION))
+        self._jobs[1].set_status(JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_SCHEDULING))
+        self._jobs[2].set_status(JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.SCHEDULED))
 
         self._services.append(MockMonitorService(MockMonitor(monitored_jobs=self._jobs)))
 
@@ -141,9 +141,9 @@ class TestMonitorService(unittest.TestCase):
         for j in self._jobs:
             self._original_statuses.append(j.status)
 
-        self._jobs[0].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_SCHEDULING)
-        self._jobs[1].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.SCHEDULED)
-        self._jobs[2].status = JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.RUNNING)
+        self._jobs[0].set_status(JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.AWAITING_SCHEDULING))
+        self._jobs[1].set_status(JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.SCHEDULED))
+        self._jobs[2].set_status(JobStatus(JobExecPhase.MODEL_EXEC, JobExecStep.RUNNING))
 
         self._job_ids = list()
         self._jobs_by_id = dict()
@@ -947,7 +947,7 @@ class TestMonitorService(unittest.TestCase):
         get_next_one = False
         for status in self._generate_all_status_values():
             if get_next_one:
-                job.status = status
+                job.set_status(status)
                 break
             elif status == original_status:
                 get_next_one = True
@@ -978,7 +978,7 @@ class TestMonitorService(unittest.TestCase):
 
         for status in self._generate_all_status_values():
             if get_next_one:
-                job.status = status
+                job.set_status(status)
                 break
             elif status == original_status:
                 get_next_one = True
@@ -1004,7 +1004,7 @@ class TestMonitorService(unittest.TestCase):
         get_next_one = False
         for status in self._generate_all_status_values():
             if get_next_one:
-                job.status = status
+                job.set_status(status)
                 break
             elif status == original_status:
                 get_next_one = True


### PR DESCRIPTION
Just some chores. Switch from deprecated set by attribute to setters. This gets rid of warnings in tests.