### PR TITLE
Dataset usage tracking and purging of expired temporary datasets

### DIFF
--- a/python/lib/core/dmod/core/dataset.py
+++ b/python/lib/core/dmod/core/dataset.py
@@ -568,6 +568,35 @@ class DatasetManager(ABC):
         """
         pass
 
+    def create_temporary(self, expires_on: Optional[datetime] = None, **kwargs) -> Dataset:
+        """
+        Convenience method that always creates a temporary dataset, and by default will have it expire after 1 day.
+
+        This method essentially just returns a nested call to ::method:`create`.  Its purpose is simply to make sure
+        that a non-``None`` argument is passed for the ``expires_on`` param.  It will provide a value for this param on
+        its own of ``datetime.now() + timedelta(days=1)``.  It also can accept a specified ``expires_on`` and simply
+        pass that through.
+
+        Parameters
+        ----------
+        expires_on: Optional[datetime]
+            Optional explicit expire time.
+        kwargs
+            Other keyword args passed in nested call to ::method:`create`.
+
+        Returns
+        -------
+        Dataset
+            A newly created temporary dataset instance ready for use.
+
+        See Also
+        -------
+        create
+        """
+        if expires_on is None:
+            expires_on = datetime.now() + timedelta(days=1)
+        return self.create(expires_on=expires_on, **kwargs)
+
     @abstractmethod
     def delete(self, dataset: Dataset, **kwargs) -> bool:
         """

--- a/python/lib/core/dmod/core/dataset.py
+++ b/python/lib/core/dmod/core/dataset.py
@@ -11,6 +11,7 @@ from .serializable import Serializable, ResultIndicator
 from .enum import PydanticEnum
 from typing import Any, Callable, ClassVar, Dict, FrozenSet, List, Optional, Set, Tuple, Type, Union
 from pydantic import Field, validator, root_validator, PrivateAttr
+from pydantic.fields import ModelField
 from uuid import UUID, uuid4
 
 
@@ -135,8 +136,8 @@ class Dataset(Serializable):
         return datetime.strptime(v, cls.get_datetime_str_format())
 
     @validator("created_on", "last_updated", "expires")
-    def drop_microseconds(cls, v: datetime):
-        return v.replace(microsecond=0)
+    def drop_microseconds(cls, v: datetime, field: ModelField):
+        return v.replace(microsecond=0) if (field.required or v is not None) else v
 
     @validator("dataset_type")
     def set_default_dataset_type(cls, value: Union[str, DatasetType] = None) -> DatasetType:

--- a/python/lib/core/dmod/test/test_dataset_manager.py
+++ b/python/lib/core/dmod/test/test_dataset_manager.py
@@ -1,0 +1,139 @@
+import unittest
+from uuid import uuid4
+from ..core.dataset import Dataset, DatasetManager, DatasetType, InitialDataAdder
+from ..core.meta_data import DataCategory, DataDomain, DataFormat, DiscreteRestriction, StandardDatasetIndex
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional, Set, Tuple, Union
+
+
+class MockDatasetManager(DatasetManager):
+
+    ACCESS_LOC = "location_0"
+
+    def add_data(self, dataset_name: str, dest: str, data: Optional[bytes] = None, source: Optional[str] = None,
+                 is_temp: bool = False, **kwargs) -> bool:
+        pass
+
+    def combine_partials_into_composite(self, dataset_name: str, item_name: str, combined_list: List[str]) -> bool:
+        pass
+
+    def create(self, name: str, category: DataCategory, domain: DataDomain, is_read_only: bool,
+               initial_data: Optional[InitialDataAdder] = None, expires_on: Optional[datetime] = None) -> Dataset:
+        """
+        A trivial implementation, intended just to test that the convenience method ::method:`create_temporary` works.
+
+        Parameters
+        ----------
+        name
+        category
+        domain
+        is_read_only
+        initial_data
+        expires_on
+
+        Returns
+        -------
+
+        """
+        return Dataset(name=name, category=category, data_domain=domain, is_read_only=is_read_only, expires=expires_on,
+                       access_location=self.ACCESS_LOC)
+
+    def delete(self, dataset: Dataset, **kwargs) -> bool:
+        pass
+
+    @property
+    def data_chunking_params(self) -> Optional[Tuple[str, str]]:
+        pass
+
+    def get_data(self, dataset_name: str, item_name: str, **kwargs) -> Union[bytes, Any]:
+        pass
+
+    def list_files(self, dataset_name: str, **kwargs) -> List[str]:
+        pass
+
+    def reload(self, reload_from: str, serialized_item: Optional[str] = None) -> Dataset:
+        pass
+
+    @property
+    def supported_dataset_types(self) -> Set[DatasetType]:
+        pass
+
+
+class TestDatasetManager(unittest.TestCase):
+
+    def setUp(self):
+        self._manager = MockDatasetManager()
+
+        self._ex_datasets: Dict[int, Dataset] = dict()
+
+        # Ex dataset 1
+        ex_idx = 1
+        disc_rest = DiscreteRestriction(StandardDatasetIndex.CATCHMENT_ID, values=['cat-1', 'cat-2', 'cat-3'])
+        domain = DataDomain(data_format=DataFormat.NGEN_REALIZATION_CONFIG, discrete_restrictions=[disc_rest])
+        self._ex_datasets[ex_idx] = Dataset(name="test_ds_1", category=DataCategory.CONFIG, data_domain=domain,
+                                            access_location=self._manager.ACCESS_LOC, is_read_only=False)
+
+    def tearDown(self):
+        pass
+
+    def test_create_temporary_1_a(self):
+        """ Test that creating with implied expire gives a temporary dataset. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+
+        dataset_w_create_temp = self._manager.create_temporary(name=base_dataset.name, category=base_dataset.category,
+                                                               domain=base_dataset.data_domain,
+                                                               is_read_only=base_dataset.is_read_only)
+        self.assertTrue(dataset_w_create_temp.is_temporary)
+
+    def test_create_temporary_1_b(self):
+        """ Test that creating with implied expire gives a temporary dataset with expected (roughly) expires_on. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+
+        # We don't get direct access to ``now()`` in advance, so track times and make sure we are within some bounds
+        pre_create_time = datetime.now()
+        created_dataset = self._manager.create_temporary(name=base_dataset.name, category=base_dataset.category,
+                                                         domain=base_dataset.data_domain,
+                                                         is_read_only=base_dataset.is_read_only)
+        post_create_time = datetime.now()
+
+        self.assertLessEqual(created_dataset.expires, (post_create_time+timedelta(days=1)))
+        # Drop amounts less than a second, as the expires attribute does this
+        self.assertGreaterEqual(created_dataset.expires, (pre_create_time.replace(microsecond=0)+timedelta(days=1)))
+
+    def test_create_temporary_1_c(self):
+        """ Test that creating with implied expire (a 1-day-from-now) gives equivalent to regular (explicit) create. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+
+        dataset_w_create_temp = self._manager.create_temporary(name=base_dataset.name, category=base_dataset.category,
+                                                               domain=base_dataset.data_domain,
+                                                               is_read_only=base_dataset.is_read_only)
+        dataset_w_create = self._manager.create(name=base_dataset.name, category=base_dataset.category,
+                                                domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only,
+                                                expires_on=dataset_w_create_temp.expires)
+        # Have to manipulate a bit here to make sure the UUIDs match, as create itself doesn't account for them directly
+        dataset_w_create.uuid = dataset_w_create_temp.uuid
+
+        self.assertEqual(dataset_w_create, dataset_w_create_temp)
+
+    def test_create_temporary_2_a(self):
+        """ Test that creating with explicit expire gives equivalent to regular explicit create. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+
+        expire_time = datetime.now() + timedelta(days=1, hours=3, minutes=5)
+
+        dataset_w_create = self._manager.create(name=base_dataset.name, category=base_dataset.category,
+                                                domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only,
+                                                expires_on=expire_time)
+        dataset_w_create_temp = self._manager.create_temporary(name=base_dataset.name, category=base_dataset.category,
+                                                               domain=base_dataset.data_domain,
+                                                               is_read_only=base_dataset.is_read_only,
+                                                               expires_on=expire_time)
+
+        # Have to manipulate a bit here to make sure the UUIDs match, as create itself doesn't account for them directly
+        dataset_w_create_temp.uuid = dataset_w_create.uuid
+
+        self.assertEqual(dataset_w_create, dataset_w_create_temp)

--- a/python/lib/core/dmod/test/test_dataset_manager.py
+++ b/python/lib/core/dmod/test/test_dataset_manager.py
@@ -1,9 +1,20 @@
 import unittest
-from uuid import uuid4
-from ..core.dataset import Dataset, DatasetManager, DatasetType, InitialDataAdder
+from uuid import uuid4, UUID
+from ..core.dataset import Dataset, DatasetManager, DatasetType, DatasetUser, InitialDataAdder
 from ..core.meta_data import DataCategory, DataDomain, DataFormat, DiscreteRestriction, StandardDatasetIndex
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
+
+
+class MockDatasetUser(DatasetUser):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._uuid = uuid4()
+
+    @property
+    def uuid(self) -> UUID:
+        return self._uuid
 
 
 class MockDatasetManager(DatasetManager):
@@ -20,7 +31,7 @@ class MockDatasetManager(DatasetManager):
     def create(self, name: str, category: DataCategory, domain: DataDomain, is_read_only: bool,
                initial_data: Optional[InitialDataAdder] = None, expires_on: Optional[datetime] = None) -> Dataset:
         """
-        A trivial implementation, intended just to test that the convenience method ::method:`create_temporary` works.
+        Trivial implementation, intended to do just enough to test other methods provided by abstract superclass.
 
         Parameters
         ----------
@@ -35,8 +46,10 @@ class MockDatasetManager(DatasetManager):
         -------
 
         """
-        return Dataset(name=name, category=category, data_domain=domain, is_read_only=is_read_only, expires=expires_on,
-                       access_location=self.ACCESS_LOC)
+        ds = Dataset(name=name, category=category, data_domain=domain, is_read_only=is_read_only, expires=expires_on,
+                     manager=self, created_on=datetime.now(), access_location=self.ACCESS_LOC)
+        self._datasets[name] = ds
+        return ds
 
     def delete(self, dataset: Dataset, **kwargs) -> bool:
         pass
@@ -65,6 +78,7 @@ class TestDatasetManager(unittest.TestCase):
         self._manager = MockDatasetManager()
 
         self._ex_datasets: Dict[int, Dataset] = dict()
+        self._ex_ds_users: Dict[int, DatasetUser] = dict()
 
         # Ex dataset 1
         ex_idx = 1
@@ -72,6 +86,8 @@ class TestDatasetManager(unittest.TestCase):
         domain = DataDomain(data_format=DataFormat.NGEN_REALIZATION_CONFIG, discrete_restrictions=[disc_rest])
         self._ex_datasets[ex_idx] = Dataset(name="test_ds_1", category=DataCategory.CONFIG, data_domain=domain,
                                             access_location=self._manager.ACCESS_LOC, is_read_only=False)
+        # Ex user 1
+        self._ex_ds_users[ex_idx] = MockDatasetUser()
 
     def tearDown(self):
         pass
@@ -137,3 +153,180 @@ class TestDatasetManager(unittest.TestCase):
         dataset_w_create_temp.uuid = dataset_w_create.uuid
 
         self.assertEqual(dataset_w_create, dataset_w_create_temp)
+
+    def test_link_user_1_a(self):
+        """ Test that linking a user puts the user in the set of linked users. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+        user = self._ex_ds_users[ex_idx]
+
+        dataset = self._manager.create(name=base_dataset.name, category=base_dataset.category,
+                                       domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+        self.assertFalse(user.uuid in self._manager.get_dataset_user_ids())
+
+        self._manager.link_user(user=user, dataset=dataset)
+        self.assertTrue(user.uuid in self._manager.get_dataset_user_ids())
+
+    def test_link_user_1_b(self):
+        """ Test that looking up an unlinked a user results in an exception. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+        user = self._ex_ds_users[ex_idx]
+
+        self.assertFalse(base_dataset.name in self._manager.datasets)
+        dataset = self._manager.create(name=base_dataset.name, category=base_dataset.category,
+                                       domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+        self.assertTrue(base_dataset.name in self._manager.datasets)
+
+        self.assertRaises(ValueError, self._manager.get_dataset_user, user.uuid)
+
+    def test_link_user_1_c(self):
+        """ Test that linking a user makes it possible to look them up. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+        user = self._ex_ds_users[ex_idx]
+
+        dataset = self._manager.create(name=base_dataset.name, category=base_dataset.category,
+                                       domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+        self.assertFalse(user.uuid in self._manager.get_dataset_user_ids())
+
+        self._manager.link_user(user=user, dataset=dataset)
+        lookup_user = self._manager.get_dataset_user(user.uuid)
+        self.assertEqual(user, lookup_user)
+
+    def test_link_user_1_d(self):
+        """ Test that linking a user to two datasets associates them with both. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+        user = self._ex_ds_users[ex_idx]
+
+        dataset_1 = self._manager.create(name=f"{base_dataset.name}_1", category=base_dataset.category,
+                                         domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+        dataset_2 = self._manager.create(name=f"{base_dataset.name}_2", category=base_dataset.category,
+                                         domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+
+        self.assertFalse(user.uuid in self._manager.get_dataset_user_ids())
+
+        self._manager.link_user(user=user, dataset=dataset_1)
+        self._manager.link_user(user=user, dataset=dataset_2)
+
+        self.assertNotEqual(dataset_1.name, dataset_2.name)
+        self.assertIn(user.uuid, self._manager.get_user_ids_for_dataset(dataset_1.name))
+        self.assertIn(user.uuid, self._manager.get_user_ids_for_dataset(dataset_2.name))
+
+    def test_get_dataset_user_ids_0_a(self):
+        """ Test that a manager starts off with no dataset users by default. """
+        self.assertEqual(len(self._manager.get_dataset_user_ids()), 0)
+
+    def test_unlink_user_1_a(self):
+        """ Test that unlinking a user makes it no longer possible to look them up. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+        user = self._ex_ds_users[ex_idx]
+
+        dataset = self._manager.create(name=base_dataset.name, category=base_dataset.category,
+                                       domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+        self.assertFalse(user.uuid in self._manager.get_dataset_user_ids())
+
+        self._manager.link_user(user=user, dataset=dataset)
+        self.assertTrue(user.uuid in self._manager.get_dataset_user_ids())
+
+        self._manager.unlink_user(user=user, dataset=dataset)
+        self.assertFalse(user.uuid in self._manager.get_dataset_user_ids())
+
+    def test_unlink_user_1_b(self):
+        """ Test that unlinking a user takes them out of set for dataset. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+        user = self._ex_ds_users[ex_idx]
+
+        dataset = self._manager.create(name=base_dataset.name, category=base_dataset.category,
+                                       domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+        self.assertFalse(user.uuid in self._manager.get_user_ids_for_dataset(dataset_name=dataset.name))
+
+        self._manager.link_user(user=user, dataset=dataset)
+        self.assertTrue(user.uuid in self._manager.get_user_ids_for_dataset(dataset_name=dataset.name))
+
+        self._manager.unlink_user(user=user, dataset=dataset)
+        self.assertFalse(user.uuid in self._manager.get_user_ids_for_dataset(dataset_name=dataset.name))
+
+    def test_unlink_user_1_c(self):
+        """ Test that unlinking a user takes them out of linked set for that dataset, but not for others. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+        user = self._ex_ds_users[ex_idx]
+
+        dataset_1 = self._manager.create(name=f"{base_dataset.name}_1", category=base_dataset.category,
+                                         domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+        dataset_2 = self._manager.create(name=f"{base_dataset.name}_2", category=base_dataset.category,
+                                         domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+
+        self.assertFalse(user.uuid in self._manager.get_user_ids_for_dataset(dataset_name=dataset_1.name))
+        self.assertFalse(user.uuid in self._manager.get_user_ids_for_dataset(dataset_name=dataset_2.name))
+
+        self._manager.link_user(user=user, dataset=dataset_1)
+        self._manager.link_user(user=user, dataset=dataset_2)
+        self.assertTrue(user.uuid in self._manager.get_user_ids_for_dataset(dataset_name=dataset_1.name))
+        self.assertTrue(user.uuid in self._manager.get_user_ids_for_dataset(dataset_name=dataset_2.name))
+
+        self._manager.unlink_user(user=user, dataset=dataset_1)
+        self.assertFalse(user.uuid in self._manager.get_user_ids_for_dataset(dataset_name=dataset_1.name))
+        self.assertTrue(user.uuid in self._manager.get_user_ids_for_dataset(dataset_name=dataset_2.name))
+
+    def test_unlink_user_1_d(self):
+        """ Test that unlinked user can still be found if they were linked to others. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+        user = self._ex_ds_users[ex_idx]
+
+        dataset_1 = self._manager.create(name=f"{base_dataset.name}_1", category=base_dataset.category,
+                                         domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+        dataset_2 = self._manager.create(name=f"{base_dataset.name}_2", category=base_dataset.category,
+                                         domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+
+        self.assertFalse(user.uuid in self._manager.get_dataset_user_ids())
+
+        self._manager.link_user(user=user, dataset=dataset_1)
+        self._manager.link_user(user=user, dataset=dataset_2)
+
+        self.assertTrue(user.uuid in self._manager.get_dataset_user_ids())
+
+        self._manager.unlink_user(user=user, dataset=dataset_1)
+        self.assertTrue(user.uuid in self._manager.get_dataset_user_ids())
+
+    def test_unlink_user_1_e(self):
+        """ Test that unlinking returns false if the user was not linked. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+        user = self._ex_ds_users[ex_idx]
+
+        dataset_1 = self._manager.create(name=f"{base_dataset.name}_1", category=base_dataset.category,
+                                         domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+
+        self.assertFalse(self._manager.unlink_user(user=user, dataset=dataset_1))
+
+    def test_unlink_user_1_f(self):
+        """ Test that unlinking returns true if the user was linked. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+        user = self._ex_ds_users[ex_idx]
+
+        dataset_1 = self._manager.create(name=f"{base_dataset.name}_1", category=base_dataset.category,
+                                         domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+        self._manager.link_user(user=user, dataset=dataset_1)
+
+        self.assertTrue(self._manager.unlink_user(user=user, dataset=dataset_1))
+
+    def test_get_user_ids_for_dataset_1_a(self):
+        """ Test that function works after linking. """
+        ex_idx = 1
+        base_dataset = self._ex_datasets[ex_idx]
+        user = self._ex_ds_users[ex_idx]
+
+        dataset = self._manager.create(name=base_dataset.name, category=base_dataset.category,
+                                       domain=base_dataset.data_domain, is_read_only=base_dataset.is_read_only)
+        self.assertFalse(user.uuid in self._manager.get_user_ids_for_dataset(dataset_name=dataset.name))
+
+        self._manager.link_user(user=user, dataset=dataset)
+        self.assertTrue(user.uuid in self._manager.get_user_ids_for_dataset(dataset_name=dataset.name))
+

--- a/python/services/dataservice/dmod/dataservice/__main__.py
+++ b/python/services/dataservice/dmod/dataservice/__main__.py
@@ -157,6 +157,7 @@ def main():
     # Setup other required async tasks
     service_manager.add_async_task(service_manager.manage_required_data_checks())
     service_manager.add_async_task(service_manager.manage_data_provision())
+    service_manager.add_async_task(service_manager.manage_temp_datasets())
 
     service_manager.run()
 

--- a/python/services/dataservice/dmod/dataservice/data_derive_util.py
+++ b/python/services/dataservice/dmod/dataservice/data_derive_util.py
@@ -7,8 +7,6 @@ from dmod.core.meta_data import DataCategory, DataDomain, DataFormat, DataRequir
 from dmod.core.exception import DmodRuntimeError
 from dmod.core.dataset import Dataset, DatasetManager, DatasetType
 from dmod.scheduler.job import Job, JobExecStep
-from ngen.config.configurations import Forcing, Time
-from ngen.config.realization import NgenRealization, Realization
 from typing import Dict, List, Optional
 
 
@@ -100,8 +98,8 @@ class DataDeriveUtil:
         data_adder = CompositeConfigDataAdder(requirement=requirement, job=job, hydrofabric_id=hydrofabric_id,
                                               all_dataset_managers=self._all_data_managers, dataset_name=ds_name,
                                               dataset_manager=manager)
-        dataset: Dataset = manager.create(name=ds_name, category=DataCategory.CONFIG, domain=domain, is_read_only=False,
-                                          initial_data=data_adder)
+        dataset: Dataset = manager.create_temporary(name=ds_name, category=DataCategory.CONFIG, domain=domain,
+                                                    is_read_only=False, initial_data=data_adder)
 
         self._apply_dataset_to_requirement(dataset=dataset, requirement=requirement, job=job)
 
@@ -132,11 +130,11 @@ class DataDeriveUtil:
         domain = DataDomain(data_format=req_domain.data_format, continuous_restrictions=continuous_restricts,
                             discrete_restrictions=discrete_restricts)
 
-        dataset: Dataset = self._all_data_managers[ds_type].create(name=ds_name,
-                                                                   category=DataCategory.CONFIG,
-                                                                   domain=domain,
-                                                                   is_read_only=False,
-                                                                   initial_data=initial_data)
+        dataset: Dataset = self._all_data_managers[ds_type].create_temporary(name=ds_name,
+                                                                             category=DataCategory.CONFIG,
+                                                                             domain=domain,
+                                                                             is_read_only=False,
+                                                                             initial_data=initial_data)
 
         self._apply_dataset_to_requirement(dataset=dataset, requirement=requirement, job=job)
 

--- a/python/services/dataservice/dmod/dataservice/dataset_user_impl.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_user_impl.py
@@ -1,0 +1,40 @@
+from dmod.core.dataset import DatasetUser
+from dmod.scheduler.job import Job
+from typing import Union
+from uuid import UUID
+
+
+class JobDatasetUser(DatasetUser):
+    """
+    Implementation that also holds a job object and represents that job's role as the user of datasets.
+    """
+
+    def __init__(self, job: Union[Job, UUID, str], *args, **kwargs):
+        """
+
+        Parameters
+        ----------
+        job: Union[Job, UUID, str]
+            The associated job itself or its unique id.
+        args
+        kwargs
+        """
+        super().__init__(*args, **kwargs)
+        if isinstance(job, Job):
+            self._job_uuid = UUID(job.job_id)
+        elif isinstance(job, str):
+            self._job_uuid = UUID(job)
+        else:
+            self._job_uuid = job
+
+    @property
+    def uuid(self) -> UUID:
+        """
+        UUID for this instance.
+
+        Returns
+        -------
+        UUID
+            UUID for this instance.
+        """
+        return self._job_uuid

--- a/python/services/dataservice/dmod/dataservice/service.py
+++ b/python/services/dataservice/dmod/dataservice/service.py
@@ -945,7 +945,7 @@ class ServiceManager(WebSocketInterface):
             self._job_util.unlock_active_jobs(lock_id)
             await asyncio.sleep(5)
 
-    async def manage_temp_datasets(self):
+    async def manage_temp_datasets(self) -> typing.NoReturn:
         """
         Async task for managing temporary datasets, including updating expire times and purging of expired datasets.
         """

--- a/python/services/dataservice/dmod/dataservice/service.py
+++ b/python/services/dataservice/dmod/dataservice/service.py
@@ -18,7 +18,7 @@ from dmod.modeldata.data.filesystem_manager import FilesystemDatasetManager
 from dmod.scheduler import SimpleDockerUtil
 from dmod.scheduler.job import Job, JobExecStep, JobUtil
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
+from typing import Dict, List, NoReturn, Optional, Set, Tuple, Type, TypeVar, Union
 from uuid import UUID, uuid4
 from websockets import WebSocketServerProtocol
 from .dataset_inquery_util import DatasetInqueryUtil
@@ -945,7 +945,7 @@ class ServiceManager(WebSocketInterface):
             self._job_util.unlock_active_jobs(lock_id)
             await asyncio.sleep(5)
 
-    async def manage_temp_datasets(self) -> typing.NoReturn:
+    async def manage_temp_datasets(self) -> NoReturn:
         """
         Async task for managing temporary datasets, including updating expire times and purging of expired datasets.
         """


### PR DESCRIPTION
Adds functionality to maintain links between datasets and things using the datasets (e.g., a job), in order to ensure that the life of temporary datasets is extended based on their use.

Also adds service functionality to periodically purge temporary datasets that have expired.