### PR TITLE
test: add `env_vars` pytest.ini option

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,9 @@
+
 [pytest]
 addopts = --import-mode=importlib
+; environment variables that will be added before tests are run
+; key=value pairs with no spaces
+; env_vars =
 ; key=value pairs with no spaces
 it_env_vars =
     ; A name for the Docker container used to run a Redis instance during integration testing


### PR DESCRIPTION
use `env_vars` key in `pytest.ini` to set environment variables that will be set before tests run.