### PR TITLE
chore: add missing `dmod.core` dep

### DIFF
--- a/python/lib/evaluations/setup.py
+++ b/python/lib/evaluations/setup.py
@@ -21,6 +21,7 @@ setup(
     url='',
     license='',
     install_requires=[
+        'dmod-core',
         'dmod-metrics',
         'pandas',
         'xarray',

--- a/python/lib/metrics/setup.py
+++ b/python/lib/metrics/setup.py
@@ -20,6 +20,6 @@ setup(
     author_email='',
     url='',
     license='',
-    install_requires=['scikit-learn', 'pandas'],
+    install_requires=['dmod.core', 'scikit-learn', 'pandas'],
     packages=find_namespace_packages(exclude=['dmod.test', 'schemas', 'ssl', 'src'])
 )


### PR DESCRIPTION
`dmod.core` is required by both metrics and evaluation but was not listed in `setup.py`. This simply adds those missing deps.