### PR TITLE
refactor: remove `_get_async_loop` from `EchoHandler`

### DIFF
--- a/python/lib/communication/dmod/communication/websocket_interface.py
+++ b/python/lib/communication/dmod/communication/websocket_interface.py
@@ -28,12 +28,6 @@ from typing import Dict, List, Optional, Tuple, Type
 from websockets import WebSocketServerProtocol
 from .async_service import AsyncServiceInterface
 
-#logging.basicConfig(
-#    level=logging.ERROR,
-#    format="%(asctime)s,%(msecs)d %(levelname)s: %(message)s",
-#    datefmt="%H:%M:%S"
-#)
-
 
 class WebSocketInterface(AsyncServiceInterface, ABC):
     """

--- a/python/lib/communication/dmod/communication/websocket_interface.py
+++ b/python/lib/communication/dmod/communication/websocket_interface.py
@@ -524,18 +524,6 @@ class EchoHandler(WebSocketInterface):
         """
         return cls._PARSEABLE_REQUEST_TYPES
 
-    @classmethod
-    def _get_async_loop(cls):
-        """
-        Override of default, to provide a new, non-primary loop for testing purposes.
-
-        Returns
-        -------
-        AbstractEventLoop
-            a new asyncio event loop
-        """
-        return asyncio.new_event_loop()
-
     async def listener(self, websocket: WebSocketServerProtocol, path):
         received_data = await websocket.recv()
         print("Echo Listener")


### PR DESCRIPTION
refactor: remove _get_async_loop from EchoHandler. Caused `IntegrationTestWebSocketInterface::test_listener_1a` to fail after c31e1a6.