### PR TITLE
chore: pin `pytest~=8.0.0` until pytest/12074 is fixed

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -144,6 +144,6 @@ jobs:
       - name: Run Tests
         run: |
           . dmod_venv/bin/activate
-          python3 -m pip install pytest
+          python3 -m pip install pytest~=8.0.0
           python3 -m pytest -o python_files="it_*.py" -o env_vars='IT_REDIS_CONTAINER_PASS="DPXzqRqjhsXokOVQcPUqOJuzKePMsfUc" IT_REDIS_CONTAINER_HOST_PORT=19639 MODEL_EXEC_ACCESS_KEY=dmod MODEL_EXEC_SECRET_KEY=password'
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,8 @@
 
 [pytest]
 addopts = --import-mode=importlib
-consider_namespace_packages = true
+; TODO: uncomment once https://github.com/pytest-dev/pytest/pull/12074 is resolved
+; consider_namespace_packages = true
 ; environment variables that will be added before tests are run
 ; key=value pairs with no spaces
 ; env_vars =


### PR DESCRIPTION
Pin `pytest~=8.0.0` until https://github.com/pytest-dev/pytest/issues/12112 is resolved. Having read through some recent issues, `pytest` pulled their `8.1.0` release and are having some backwards compatibility issues. Should be resolved by the end of the week.