### PR TITLE
feat: add `DatasetManagerCollection`; refactor data service to use new abstraction

### DIFF
--- a/python/services/dataservice/dmod/dataservice/__main__.py
+++ b/python/services/dataservice/dmod/dataservice/__main__.py
@@ -9,6 +9,7 @@ import argparse
 from . import name as package_name
 from .service import ServiceManager
 from .service_settings import ServiceSettings
+from .dataset_manager_collection import DatasetManagerCollection
 from dmod.scheduler.job import DefaultJobUtilFactory
 from pathlib import Path
 from socket import gethostname
@@ -143,9 +144,16 @@ def main():
     job_util = DefaultJobUtilFactory.factory_create(redis_host=args.redis_host, redis_port=args.redis_port,
                                                     redis_pass=redis_pass)
 
+    dataset_manager_collection = DatasetManagerCollection()
     # Initiate a service manager WebsocketHandler implementation for primary messaging and async task loops
-    service_manager = ServiceManager(job_util=job_util, listen_host=listen_host, port=args.port,
-                                     ssl_dir=Path(args.ssl_dir), settings=service_settings)
+    service_manager = ServiceManager(
+        job_util=job_util,
+        listen_host=listen_host,
+        port=args.port,
+        ssl_dir=Path(args.ssl_dir),
+        settings=service_settings,
+        dataset_manager_collection=dataset_manager_collection,
+    )
 
     # If we are set to use the object store ...
     if use_obj_store:

--- a/python/services/dataservice/dmod/dataservice/dataset_manager_collection.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_manager_collection.py
@@ -59,7 +59,7 @@ class DatasetManagerCollection:
         DmodRuntimeError
             If a manager for the same DatasetType already exists.
         DmodRuntimeError
-            If the provided manager manages datasets already in the collection.
+            If the manager to be added has a dataset with a name that duplicates the name of a known dataset from one of this instance's other managers.
         """
         # In this case, just return, as the manager is already added
         if manager.uuid in set(m.uuid for m in self._managers.values()):

--- a/python/services/dataservice/dmod/dataservice/dataset_manager_collection.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_manager_collection.py
@@ -1,0 +1,99 @@
+import dataclasses
+from typing import Dict, Iterable, Tuple
+
+from dmod.core.dataset import Dataset, DatasetManager, DatasetType
+from dmod.core.exception import DmodRuntimeError
+
+
+@dataclasses.dataclass
+class DatasetManagerCollection:
+    """
+    Collection of DatasetManager objects and their associated DatasetType.
+    For each DatasetType, there must be only one DatasetManager.
+    A given DatasetManager instance may be associated with multiple DatasetTypes.
+    """
+    _managers: Dict[DatasetType, DatasetManager] = dataclasses.field(
+        default_factory=dict, init=False
+    )
+
+    def manager(self, dataset_type: DatasetType) -> DatasetManager:
+        """
+        Return the manager for the given dataset type.
+
+        Parameters
+        ----------
+        dataset_type : DatasetType
+
+        Returns
+        -------
+        DatasetManager
+            Manager Associated with the given dataset type.
+
+        Raises
+        ------
+        KeyError
+            If there is not a manager for the given dataset type.
+        """
+        return self._managers[dataset_type]
+
+    def managers(self) -> Iterable[Tuple[DatasetType, DatasetManager]]:
+        """
+        Iterable of all managers in collection as tuples of (DatasetType, DatasetManager).
+
+        Returns
+        -------
+        Iterable[Tuple[DatasetType, DatasetManager]]
+        """
+        return ((t, m) for (t, m) in self._managers.items())
+
+    def add(self, manager: DatasetManager) -> None:
+        """
+        Add a manager. If a manager with the same UUID is already in the collection, it ignored.
+
+        Parameters
+        ----------
+        manager : DatasetManager
+
+        Raises
+        ------
+        DmodRuntimeError
+            If a manager for the same DatasetType already exists.
+        DmodRuntimeError
+            If the provided manager manages datasets already in the collection.
+        """
+        # In this case, just return, as the manager is already added
+        if manager.uuid in set(m.uuid for m in self._managers.values()):
+            return
+
+        known_dataset_names = set(self.known_datasets().keys())
+        if not known_dataset_names.isdisjoint(manager.datasets.keys()):
+            duplicates = known_dataset_names.intersection(manager.datasets.keys())
+            msg = "Can't add {} to service with already known dataset names {}."
+            raise DmodRuntimeError(msg.format(manager.__class__.__name__, duplicates))
+
+        if not manager.supported_dataset_types.isdisjoint(self._managers.keys()):
+            duplicates = manager.supported_dataset_types.intersection(
+                self._managers.keys()
+            )
+            msg = "Can't add new {} to service for managing already managed dataset types {}."
+            raise DmodRuntimeError(msg.format(manager.__class__.__name__, duplicates))
+
+        for dataset_type in manager.supported_dataset_types:
+            self._managers[dataset_type] = manager
+
+    def known_datasets(self) -> Dict[str, Dataset]:
+        """
+        Get real-time mapping of all datasets known to this instance via its managers, in a map keyed by dataset name.
+
+        This is implemented as a function, and not a property, since it is mutable and could change without this service
+        instance being directly notified.  As such, a new collection object is created and returned on every call.
+
+        Returns
+        -------
+        Dict[str, Dataset]
+            All datasets known to the service via its manager objects, in a map keyed by dataset name.
+        """
+        datasets: Dict[str, Dataset] = {}
+        for manager in self._managers.values():
+            datasets.update(manager.datasets)
+        return datasets

--- a/python/services/dataservice/dmod/dataservice/service.py
+++ b/python/services/dataservice/dmod/dataservice/service.py
@@ -129,7 +129,7 @@ class DockerS3FSPluginHelper(SimpleDockerUtil):
                                                          healthcheck=self.service_healthcheck,
                                                          secrets=secrets)
             time_sleep(5)
-            for tries in range(5):
+            for _ in range(5):
                 service.reload()
                 if all([task['Status']['State'] == task['DesiredState'] for task in service.tasks()]):
                     break

--- a/python/services/dataservice/dmod/test/test_data_inquery_util.py
+++ b/python/services/dataservice/dmod/test/test_data_inquery_util.py
@@ -4,11 +4,13 @@ import json
 
 from dmod.communication.client import get_or_create_eventloop
 from dmod.core.meta_data import DataCategory, DataDomain
-from dmod.core.dataset import Dataset
+from dmod.core.dataset import Dataset, DatasetType, DatasetManager
 from dmod.scheduler.job import RequestedJob
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Union, Tuple
-from ..dataservice.dataset_inquery_util import DatasetInqueryUtil, DatasetType, DatasetManager
+
+from ..dataservice.dataset_manager_collection import DatasetManagerCollection
+from ..dataservice.dataset_inquery_util import DatasetInqueryUtil
 
 
 class MockDataset(Dataset):
@@ -53,7 +55,7 @@ class MockDatasetManager(DatasetManager):
 
     @property
     def supported_dataset_types(self) -> Set[DatasetType]:
-        pass
+        return {DatasetType.FILESYSTEM}
 
 
 class TestDataInqueryUtil(unittest.TestCase):
@@ -116,8 +118,9 @@ class TestDataInqueryUtil(unittest.TestCase):
 
         self.manager = MockDatasetManager(datasets=self.datasets)
 
-        managers = {DatasetType.FILESYSTEM: self.manager}
-        self.data_inquery_util = DatasetInqueryUtil(data_mgrs_by_ds_type=managers)
+        managers = DatasetManagerCollection()
+        managers.add(self.manager)
+        self.data_inquery_util = DatasetInqueryUtil(dataset_manager_collection=managers)
 
         # Example 0 - without fulfillment properties set before deserialization
         cpu_count_ex_0 = 8

--- a/python/services/dataservice/dmod/test/test_dataset_manager_collection.py
+++ b/python/services/dataservice/dmod/test/test_dataset_manager_collection.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from typing import Dict, Set
+
+import git
+from dmod.core.dataset import Dataset, DatasetType
+from dmod.core.exception import DmodRuntimeError
+from dmod.dataservice.dataset_manager_collection import DatasetManagerCollection
+
+from .test_service_manager import MockDataset, MockDatasetManager
+
+
+class MockDatasetManagerSupportsMultipleTypes(MockDatasetManager):
+    @property
+    def supported_dataset_types(self) -> Set[DatasetType]:
+        return {DatasetType.FILESYSTEM, DatasetType.OBJECT_STORE}
+
+
+class TestDatasetManagerCollection(unittest.TestCase):
+    def setUp(self):
+        self.dataset_manager_collection = DatasetManagerCollection()
+
+    @property
+    def proj_root(self) -> Path:
+        return Path(git.Repo(__file__, search_parent_directories=True).working_dir)
+
+    @property
+    def datasets(self) -> Dict[str, Dataset]:
+        example_serial_datasets_dir = (
+            self.proj_root / "data/serialized_dataset_examples"
+        )
+        dataset_files = list(example_serial_datasets_dir.glob("*.json"))
+        datasets: Dict[str, Dataset] = dict()
+        for d_file in dataset_files:
+            dataset: Dataset | None = MockDataset.factory_init_from_deserialized_json(
+                json.loads(d_file.read_text())
+            )
+            assert (
+                dataset is not None
+            ), f"failed to deserialize {d_file!r} into MockDataset"
+            datasets[dataset.name] = dataset
+        return datasets
+
+    def test_add_straight_and_narrow(self):
+        dmc = DatasetManagerCollection()
+        assert len(dict(dmc.managers())) == 0
+        dm = MockDatasetManager(datasets=self.datasets)
+        dmc.add(dm)
+        self.assertSetEqual(
+            set(self.datasets.keys()).symmetric_difference(dmc.known_datasets().keys()),
+            set(),
+        )
+        for type_ in dm.supported_dataset_types:
+            self.assertEqual(dmc.manager(type_), dm)
+
+        for _, mng in dmc.managers():
+            self.assertEqual(mng, dm)
+
+    def test_add_twice_is_noop(self):
+        dmc = DatasetManagerCollection()
+        assert len(dict(dmc.managers())) == 0
+        dm = MockDatasetManager(datasets=self.datasets)
+        dmc.add(dm)
+        assert len(dict(dmc.managers())) == 1
+        dmc.add(dm)
+        assert len(dict(dmc.managers())) == 1
+
+    def test_add_cannot_have_distinct_managers_of_same_type(self):
+        dmc = DatasetManagerCollection()
+        assert len(dict(dmc.managers())) == 0
+
+        dm = MockDatasetManager(datasets=self.datasets)
+        dmc.add(dm)
+        assert len(dict(dmc.managers())) == 1
+
+        dm2 = MockDatasetManager(datasets=self.datasets)
+        with self.assertRaises(DmodRuntimeError):
+            dmc.add(dm2)
+
+    def test_add_manager_can_be_associated_with_multiple_dataset_types(self):
+        dmc = DatasetManagerCollection()
+        assert len(dict(dmc.managers())) == 0
+        dm = MockDatasetManagerSupportsMultipleTypes(datasets=self.datasets)
+        self.assertGreater(len(dm.supported_dataset_types), 1)
+        dmc.add(dm)
+        for type_ in dm.supported_dataset_types:
+            self.assertEqual(dmc.manager(type_), dm)


### PR DESCRIPTION
Add `DatasetManagerCollection` abstraction to encapsulate a collection of `DatasetManager` objects and their associated `DatasetType`. A primitive version of this already exists in the code, this PR simply abstracts and refactors the primitive version into a well defined type.


## Additions

- Add `DatasetManagerCollection` abstraction to encapsulate a collection of `DatasetManager` objects and their associated `DatasetType`.