### PR TITLE
chore: unpin `pytest` in CI 

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -144,6 +144,6 @@ jobs:
       - name: Run Tests
         run: |
           . dmod_venv/bin/activate
-          python3 -m pip install pytest~=8.0.0
+          python3 -m pip install pytest
           python3 -m pytest -o python_files="it_*.py" -o env_vars='IT_REDIS_CONTAINER_PASS="DPXzqRqjhsXokOVQcPUqOJuzKePMsfUc" IT_REDIS_CONTAINER_HOST_PORT=19639 MODEL_EXEC_ACCESS_KEY=dmod MODEL_EXEC_SECRET_KEY=password'
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,7 @@
 
 [pytest]
 addopts = --import-mode=importlib
-; TODO: uncomment once https://github.com/pytest-dev/pytest/pull/12074 is resolved
-; consider_namespace_packages = true
+consider_namespace_packages = true
 ; environment variables that will be added before tests are run
 ; key=value pairs with no spaces
 ; env_vars =


### PR DESCRIPTION
`pytest==8.1.1` was failing to discover tests correctly because of an erroneous `__init__.py` file in the source tree (#545). Remove the `pytest` version pin and add the new `consider_namespace_packages = true` `pytest` option.
 
related to #541 and #542

#545 should be merged before this