### PR TITLE
feat: port data service to FastApi; add POST endpoint for uploading data to a dataset

### DIFF
--- a/.github/workflows/testing_and_validation.yml
+++ b/.github/workflows/testing_and_validation.yml
@@ -44,7 +44,7 @@ jobs:
           . dmod_venv/bin/activate
           pip install --upgrade pip
           deactivate 
-          ./scripts/update_package.sh --venv dmod_venv --no-service-packages --dependencies
+          ./scripts/update_package.sh --venv dmod_venv --dependencies
 
       - name: Cache Package Checksums
         id: cache-packages-md5

--- a/docker/main/dataservice/entrypoint.sh
+++ b/docker/main/dataservice/entrypoint.sh
@@ -23,4 +23,4 @@ if [ -d ${UPDATED_PACKAGES_DIR:=/updated_packages} ]; then
     fi
 fi
 
-python -m ${SERVICE_PACKAGE_NAME:?}
+python -m uvicorn dmod.dataservice.rest_service:app --host "${HOST:?HOST not set}"--port "${PORT:?PORT not set}" --ssl-keyfile="${KEY_PATH?:KEY_PATH not set}" --ssl-certfile="${CERT_PATH:?CERT_PATH not set}"

--- a/docker/main/docker-deploy.yml
+++ b/docker/main/docker-deploy.yml
@@ -184,6 +184,8 @@ services:
       #- VENV_DIR=${DOCKER_REQUESTS_CONTAINER_VENV_DIR:-}
       # debugging flags
       #- UPDATED_PACKAGES_DIR=${UPDATED_PACKAGES_CONTAINER_DIR:?Updated packages directory not set, make sure this should be active}
+    # uncomment to override entry point; intended for development use ONLY
+    # entrypoint: ["python", "-m", "uvicorn", "dmod.dataservice.rest_service:app", "--port=8080", "--host=0.0.0.0"]
     working_dir: /code
     ports:
       - "${DOCKER_DATASERVICE_HOST_PORT:-3015}:${DOCKER_DATASERVICE_CONTAINER_PORT:-3015}"

--- a/python/services/dataservice/dmod/dataservice/_injectable.py
+++ b/python/services/dataservice/dmod/dataservice/_injectable.py
@@ -1,0 +1,67 @@
+"""
+Functions that injectable via FastAPI's dependency injection system.
+"""
+from functools import lru_cache
+
+from dmod.dataservice.data_derive_util import DataDeriveUtil
+from dmod.dataservice.dataset_inquery_util import DatasetInqueryUtil
+from dmod.dataservice.dataset_manager_collection import DatasetManagerCollection
+from dmod.dataservice.service_settings import ServiceSettings, service_settings
+from dmod.scheduler.job import DefaultJobUtilFactory, JobUtil
+from fastapi import Depends
+from typing_extensions import Annotated
+
+
+@lru_cache
+def dataset_manager_collection() -> DatasetManagerCollection:
+    """
+    Service singleton `DatasetManagerCollection`.
+    All handlers or service level background tasks that need a `DatasetManagerCollection` _should_
+    use this / depend on it via FastApi's dependency injection system.
+    """
+    return DatasetManagerCollection()
+
+
+@lru_cache
+def data_derive_util(
+    dmc: Annotated[DatasetManagerCollection, Depends(dataset_manager_collection)]
+) -> DataDeriveUtil:
+    """
+    Service singleton `DataDeriveUtil`.
+    All handlers or service level background tasks that need a `DataDeriveUtil` _should_
+    use this / depend on it via FastApi's dependency injection system.
+    """
+    return DataDeriveUtil(dataset_manager_collection=dmc)
+
+
+@lru_cache
+def dataset_inquery_util(
+    manager_collection: Annotated[
+        DatasetManagerCollection, Depends(dataset_manager_collection)
+    ],
+    derive_util: Annotated[DataDeriveUtil, Depends(data_derive_util)],
+) -> DatasetInqueryUtil:
+    """
+    Service singleton `DatasetInqueryUtil`.
+    All handlers or service level background tasks that need a `DatasetInqueryUtil` _should_
+    use this / depend on it via FastApi's dependency injection system.
+    """
+    return DatasetInqueryUtil(
+        dataset_manager_collection=manager_collection, derive_util=derive_util
+    )
+
+
+@lru_cache
+def job_util(
+    settings: Annotated[ServiceSettings, Depends(service_settings)]
+) -> JobUtil:
+    """
+    Service singleton `DefaultJobUtilFactory`.
+    All handlers or service level background tasks that need a `DefaultJobUtilFactory` _should_
+    use this / depend on it via FastApi's dependency injection system.
+    """
+    return DefaultJobUtilFactory.factory_create(
+        redis_host=settings.redis_host,
+        redis_port=settings.redis_port,
+        redis_pass=settings.redis_pass,
+    )

--- a/python/services/dataservice/dmod/dataservice/dataset_manager_collection.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_manager_collection.py
@@ -12,6 +12,7 @@ class DatasetManagerCollection:
     For each DatasetType, there must be only one DatasetManager.
     A given DatasetManager instance may be associated with multiple DatasetTypes.
     """
+    # TODO: consider how `__eq__` should be implemented (#598)
     _managers: Dict[DatasetType, DatasetManager] = dataclasses.field(
         default_factory=dict, init=False
     )

--- a/python/services/dataservice/dmod/dataservice/dataset_manager_collection.py
+++ b/python/services/dataservice/dmod/dataservice/dataset_manager_collection.py
@@ -16,6 +16,9 @@ class DatasetManagerCollection:
         default_factory=dict, init=False
     )
 
+    def __hash__(self) -> int:
+        return id(self)
+
     def manager(self, dataset_type: DatasetType) -> DatasetManager:
         """
         Return the manager for the given dataset type.

--- a/python/services/dataservice/dmod/dataservice/rest_service.py
+++ b/python/services/dataservice/dmod/dataservice/rest_service.py
@@ -1,25 +1,32 @@
+import asyncio
+import logging
+from contextlib import asynccontextmanager
 from pathlib import Path
-from fastapi import FastAPI, Depends, Request, Query, UploadFile
-from fastapi.responses import JSONResponse, StreamingResponse
 
-from ._version import __version__ as version
-from .errors import Error as ErrorEnum
-from .exceptions import ErrorResponseException
-from .models import (
-    Option,
-    Error,
-    DataCategory,
-    DataDomain,
-    DatasetObjectMetadata,
-    DatasetPutObjectMultipleRequest,
-    DatasetQueryResponse,
-    DatasetShortInfo,
-    QueryType,
+from dmod.core.dataset import DatasetType
+from dmod.dataservice.dataset_inquery_util import DatasetInqueryUtil
+from dmod.dataservice.dataset_manager_collection import DatasetManagerCollection
+from dmod.dataservice.service import (
+    ActiveOperationTracker,
+    DataProvisionManager,
+    DockerS3FSPluginHelper,
+    RequiredDataChecksManager,
+    ServiceManager,
+    TempDataTaskManager,
 )
-
-from typing import List, Optional
+from dmod.dataservice.service_settings import ServiceSettings, service_settings
+from dmod.modeldata.data.object_store_manager import ObjectStoreDatasetManager
+from dmod.scheduler.job import JobUtil
+from fastapi import Depends, FastAPI, Request, UploadFile, WebSocket, status
+from fastapi.responses import JSONResponse
 from typing_extensions import Annotated
 
+from . import _injectable as dep
+from ._version import __version__ as version
+from .errors import Error as Errors
+from .exceptions import ErrorResponseException
+from .models import Error
+from .service_settings import service_settings
 
 app = FastAPI(
     title="DMOD Data Service",
@@ -30,6 +37,111 @@ app = FastAPI(
         "url": "https://raw.githubusercontent.com/NOAA-OWP/owp-open-source-project-template/ed3e23a203153c4e00c4f95893f5e45631620481/LICENSE",
     },
 )
+
+
+# TODO: add feature flags for toggling background tasks
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """
+    This coroutine conducts service setup and tear down tasks. This includes setting up and starting
+    background tasks. It is split into two logical sections divided by an empty `yield` statement.
+    Everything before the `yeild` statement runs prior to the server startup. Everything after the
+    yield statement runs _during_ server shutdown.
+    """
+    # NOTE: for better or worse, this function is and probably will remain very procedural. The goal
+    # is to err on the side of clarity and locality. That likely will mean this function is a
+    # little long, but crucially does not require jumping to several different files to
+    # understand what is going on.
+    settings = service_settings()
+
+    # Initialize objects that will be injected and shared by service subsystems
+    # Initialize a job util via the default factory, which requires some Redis params
+    job_util = dep.job_util(settings)
+
+    # Datasets creation and access go through this object
+    dataset_manager_collection = dep.dataset_manager_collection()
+
+    # add dataset managers to manager collection
+    object_store_dataset_manager = _init_object_store_dataset_manager(
+        obj_store_host=settings.object_store_host,
+        port=settings.object_store_port,
+        access_key=settings.object_store_username,
+        secret_key=settings.object_store_passwd,
+    )
+    dataset_manager_collection.add(object_store_dataset_manager)
+
+    data_derive_util = dep.data_derive_util(dataset_manager_collection)
+    dataset_inquery_util = dep.dataset_inquery_util(
+        dataset_manager_collection, data_derive_util
+    )
+
+    docker_s3fs_plugin_helper = _init_docker_s3fs_plugin_helper(
+        dataset_manager_collection=dataset_manager_collection,
+        access_key=settings.object_store_username,
+        secret_key=settings.object_store_passwd,
+        settings=settings,
+    )
+
+    # count is used to signal when it is okay to remove temporary datasets
+    count = ActiveOperationTracker()
+
+    # initialize background task objects
+    required_data_checks_manager = RequiredDataChecksManager(
+        job_util=job_util,
+        dataset_manager_collection=dataset_manager_collection,
+        checks_underway_tracker=count,
+        dataset_inquery_util=dataset_inquery_util,
+    )
+    data_provision_manager = DataProvisionManager(
+        job_util=job_util,
+        dataset_manager_collection=dataset_manager_collection,
+        docker_s3fs_helper=docker_s3fs_plugin_helper,
+        data_derive_util=data_derive_util,
+        provision_underway_tracker=count,
+    )
+    temp_datasets_manager = TempDataTaskManager(
+        dataset_manager_collection=dataset_manager_collection,
+        safe_to_exec_tracker=count,
+    )
+
+    # Setup other required async tasks
+    # create single future (gather) for running background tasks
+    # this is done so it is easier to cancel them all at once
+    futs = asyncio.gather(
+        required_data_checks_manager.start(),
+        data_provision_manager.start(),
+        temp_datasets_manager.start(),
+    )
+    # create a task that runs tasks in background
+    background_tasks = asyncio.create_task(asyncio.wait_for(futs, timeout=None))
+
+    # use future like condition variable. once background tasks are done / cancelled,
+    # set its result, so whatever is awaiting it can proceed
+    done_fut = asyncio.Future()
+
+    def done_callback(_: asyncio.Task):
+        done_fut.set_result(None)
+
+    background_tasks.add_done_callback(done_callback)
+
+    yield
+    # everything after yield is run _during_ service shutdown, bearing it is not a SIGKILL
+
+    # ensure that background tasks can run any cleanup work
+    # 1. cancel tasks
+    # 2. done_callback will be called once this completes
+    # 3. done_callback sets done_fut result
+    # 4. done_fut's result is returned
+    background_tasks.cancel()
+    await done_fut
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+DatasetManagementCollectionDep = Annotated[
+    DatasetManagerCollection, Depends(dep.dataset_manager_collection)
+]
 
 
 @app.exception_handler(ErrorResponseException)
@@ -65,80 +177,101 @@ async def error_response_exception_handler(_: Request, exc: ErrorResponseExcepti
     )
 
 
-@app.post("/create")
-async def create_dataset(
-    dataset_name: str,
-    data_category: DataCategory,
-    data_domain: DataDomain,
-) -> DatasetShortInfo:
-    """Create an empty dataset"""
-    ...
-
-
-@app.get("/get_object")
-async def get_object(dataset_name: str, object_path: Path) -> StreamingResponse:
-    """Download object from dataset."""
-    ...
-
-
-@app.put("/put_object")
-async def pub_object(
+# NOTE: not sure if an optional `DataDomain` should be provided
+# NOTE: the object name should also be optional. meaning we should be able to infer it from the upload
+# NOTE: add a way to specify content type
+@app.post(
+    "/add_object",
+    tags=["datasets"],
+    description="Upload a file to an existing dataset.",
+)
+async def add_object_handler(
     dataset_name: str,
     object_name: Path,
-    object: UploadFile,
-    extract: bool = Query(
-        False,
-        description="If true, .tar.gz and .gz archive files will be extracted",
-    ),
+    obj: UploadFile,
+    service_manager: DatasetManagementCollectionDep,
 ):
-    """Add a file or archive to an existing dataset. `.tar.gz` and `.gz` archive files will be
-    extracted if 'extract' parameter is true. Overwrites existing object with identical object_name.
     """
-    ...
+    Add a file to an existing dataset.
+    Overwrites existing object with identical `object_name`.
+
+    201 created returned on success
+    """
+    success = service_manager.manager(DatasetType.OBJECT_STORE).add_data(
+        dataset_name=dataset_name, dest=object_name.as_posix(), data=obj.file
+    )
+    if not success:
+        raise ErrorResponseException(Errors.PUT_OBJECT_FAILURE)
+    return status.HTTP_201_CREATED
 
 
-@app.put("/put_objects")
-async def pub_objects(data: Annotated[DatasetPutObjectMultipleRequest, Depends()]):
-    """Add multiple files and add them to existing dataset. Overwrites existing objects with
-    identical object_names."""
-    ...
+def _service_manager(
+    util: Annotated[JobUtil, Depends(dep.job_util)],
+    service_manager: DatasetManagementCollectionDep,
+    inquery: Annotated[DatasetInqueryUtil, Depends(dep.dataset_inquery_util)],
+) -> ServiceManager:
+    """
+    return an injectable `ServiceManager` (websocket handler)
+    """
+    return ServiceManager(
+        job_util=util,
+        dataset_manager_collection=service_manager,
+        dataset_inquery_util=inquery,
+    )
 
 
-@app.get("/list_objects")
-async def list_objects(
-    dataset_name: str, prefix: Optional[Path] = None, recursive: bool = True
-) -> List[DatasetObjectMetadata]:
-    """List a dataset's objects."""
-    ...
+@app.websocket("/")
+async def websocket_handler(
+    websocket: WebSocket, manager: Annotated[ServiceManager, Depends(_service_manager)]
+):
+    await manager.listener(websocket)
 
 
-@app.get("/query", response_model_exclude_none=True)
-async def query(dataset_name: str, q: List[QueryType]) -> DatasetQueryResponse:
-    """Inquire a dataset's metadata attributes."""
-    ...
+# initialization helper functions
+def _init_object_store_dataset_manager(
+    obj_store_host: str, access_key: str, secret_key: str, port: int = 9000
+) -> ObjectStoreDatasetManager:
+    host_str = "{}:{}".format(obj_store_host, port)
+    logging.info("Initializing object store dataset manager at {}".format(host_str))
+    mgr = ObjectStoreDatasetManager(
+        obj_store_host_str=host_str, access_key=access_key, secret_key=secret_key
+    )
+    logging.info(
+        "Object store dataset manager initialized with {} existing datasets".format(
+            len(mgr.datasets)
+        )
+    )
+    return mgr
 
 
-@app.delete("/delete")
-async def delete(dataset_name: str):
-    """Delete a dataset."""
-    ...
+def _init_docker_s3fs_plugin_helper(
+    dataset_manager_collection: DatasetManagerCollection,
+    access_key: str,
+    secret_key: str,
+    settings: ServiceSettings,
+    *args,
+    **kwargs,
+) -> DockerS3FSPluginHelper:
+    s3fs_url_proto = settings.s3fs_url_protocol
+    s3fs_url_host = settings.s3fs_url_host
+    s3fs_url_port = settings.s3fs_url_port
+    if s3fs_url_host is not None:
+        s3fs_helper_url = "{}://{}:{}/".format(
+            s3fs_url_proto, s3fs_url_host, s3fs_url_port
+        )
+    else:
+        s3fs_helper_url = None
 
-
-@app.get("/search", response_model_exclude_none=True)
-async def search(
-    data_domain: DataDomain, data_category: DataCategory
-) -> Option[DatasetShortInfo]:
-    """Search for a dataset that satisfies the given `data_domain` and `data_category`
-    requirements."""
-    ...
-
-
-@app.get("/list_datasets")
-async def list_all() -> List[DatasetShortInfo]:
-    """List all datasets and their guids."""
-    ...
-
-
-@app.get("/error/{variant_name}")
-async def error(variant_name: ErrorEnum):
-    ...
+    docker_s3fs_helper = DockerS3FSPluginHelper(
+        dataset_manager_collection=dataset_manager_collection,
+        obj_store_access=access_key,
+        obj_store_secret=secret_key,
+        docker_image_name=settings.s3fs_vol_image_name,
+        docker_image_tag=settings.s3fs_vol_image_tag,
+        docker_networks=[settings.s3fs_helper_network],
+        docker_plugin_alias=settings.s3fs_plugin_alias,
+        obj_store_url=s3fs_helper_url,
+        *args,
+        **kwargs,
+    )
+    return docker_s3fs_helper


### PR DESCRIPTION
closes #538 

The goal of this PR is to port the current data service's web server backend from the python library `websockets` to the python web server framework `FastApi` _and_ create a POST endpoint for uploading data to an existing dataset. The "new" stack still utilizes the `websockets` library under the hood. However, now an [`asgi`](https://asgi.readthedocs.io/en/latest/introduction.html) server layer has been added between the `websocket` / `http` protocol layer and the application layer. This gives us flexibility if we need to move away from the `websockets` library for example, as now we can choose whatever `asgi` server is best suited to our needs. `asgi` servers typically allow selecting which protocol specific library (e.g. `websockets`, `wsproto`) is used to handle either the `http` or `websockets` protocols. For simplicity, i've selected the `uvicorn` `asgi` server which  supports the `websockets` library. We should discuss if this selection is appropriate and discuss other options before merging this.

There is some nuance in _what_ has changed in the service's network stack. The previous service used from the bottom up, python's `asycio.loop.create_server` (`websockets` calls this) to handle  `IP`, `TCP`, and `TLS`, then the `websockets` library to serialize and deserialize `HTTP`, and `websockets`. Our application code uses the abstractions provided by the `websockets` library to communicate. 

The new stack decouples the underlying websockets transport library by utilizing a `asgi` server and framework. As mentioned previously, the `asgi` server, `uvicorn` is now used. `uvicorn` is responsible for calling `asycio.loop.create_server` which still handles `IP`, `TCP`, and `TLS` however, `uvicorn` utilizes libraries like `h11` and `websockets` for example which implement the `asycio.Protocol`'s for handling HTTP and websockets protocols respectfully. `uvicorn` enables communication via the `asgi` specification, thus decoupling it from the underlying communication mechanisms (i.e. `websockets`). 

`FastApi` is an `asgi` _framework_ which sits on top of the `starlette` `asgi` framework. `starlette` does most of the work and implementing a `http` multiplexer and middleware registry among other things. `FastApi` provides a lot of niceties through its heavy integration with `pydantic` which enables request and response validation + openapi documentation. The service's http / websocket communication is now implemented using `FastApi`. In theory, this will enable us to pivot to other `asgi` servers / protocol libraries is necessary. It will also give us the added benefit of having openapi documentation which could be used to generate client code.


Potentially weird things you might come across when reviewing this PR:
- `fastapi.Depends` - `FastApi` provides a dependency injection feature for providing dependencies to a given handler. The classic example of this is a database connection. If you are familiar with `pytest` fixtures, these will look and feel similar in _use_ but not definition. It is a common pattern within the `FastApi` app community to decorate a function with `@lru_cache` to create effectively a singleton (if the function has no arguments). Ive followed this pattern for several of the dependencies required by the websocket handler.
- The `lifespan` function. This will run before the service is started _and_ while the service is shutting down. If you are familiar with `pytest` fixtures, they work almost identically. Everything before the yield is run before server startup and everything after yield is run during shutdown. As it sits, there is a lot going on in that function. It definitely become a place for the procedural code. Im personally fine with it staying that way, but I would love to hear what you all think and ways you would rather see the cruft managed.

## Additions

- `/add_object` POST endpoint. This enables adding an object to and existing dataset. Adding an object that already exists will overwrite it.


## Changes

- `FastApi` used instead of `websockets` library
- Connection can only be made to the websocket using `/` path. Previously, any valid URL path could be used. In the future, I would like to change this to `/ws`. However, this is out of scope for this change.


## TODO:
- Update service README
