### PR TITLE
refactor: remove deprecated path parameter

### DIFF
--- a/python/lib/communication/dmod/communication/registered/registered_interface.py
+++ b/python/lib/communication/dmod/communication/registered/registered_interface.py
@@ -297,13 +297,12 @@ class RegisteredWebSocketInterface(WebSocketInterface, abc.ABC):
                 return message
         return InvalidMessage(content=message_data)
 
-    async def listener(self, websocket: WebSocketServerProtocol, path):
+    async def listener(self, websocket: WebSocketServerProtocol):
         """
         Listens to the given websocket and routes messages to the desired handlers
 
         Args:
             websocket: The socket to communicate through
-            path: The path to the socket entry point on the server
         """
         client_ip = websocket.remote_address[0]
 
@@ -365,7 +364,7 @@ class RegisteredWebSocketInterface(WebSocketInterface, abc.ABC):
                     response = await handler.handle_request(
                         request=request_message,
                         source=websocket,
-                        path=path,
+                        path=websocket.path,
                         client_ip=client_ip,
                         **keyword_arguments
                     )

--- a/python/lib/communication/dmod/communication/websocket_interface.py
+++ b/python/lib/communication/dmod/communication/websocket_interface.py
@@ -282,7 +282,7 @@ class WebSocketInterface(AsyncServiceInterface, ABC):
         asyncio.create_task(self.shutdown())
 
     @abstractmethod
-    def listener(self, websocket: WebSocketServerProtocol, path):
+    def listener(self, websocket: WebSocketServerProtocol):
         """
         Abstract method to be overridden by subclasses to define the behaviour
         of the server's listener.
@@ -492,7 +492,7 @@ class NoOpHandler(WebSocketInterface):
         """
         return asyncio.new_event_loop()
 
-    async def listener(self, websocket: WebSocketServerProtocol, path):
+    async def listener(self, websocket: WebSocketServerProtocol):
         print("NoOp Listener")
         await websocket.send("")
 
@@ -518,7 +518,7 @@ class EchoHandler(WebSocketInterface):
         """
         return cls._PARSEABLE_REQUEST_TYPES
 
-    async def listener(self, websocket: WebSocketServerProtocol, path):
+    async def listener(self, websocket: WebSocketServerProtocol):
         received_data = await websocket.recv()
         print("Echo Listener")
         await websocket.send(received_data)

--- a/python/lib/communication/setup.py
+++ b/python/lib/communication/setup.py
@@ -21,7 +21,7 @@ setup(
     url='',
     license='',
     include_package_data=True,
-    install_requires=['dmod-core>=0.11.0', 'websockets>=8.1', 'jsonschema', 'redis', 'pydantic>=1.10.8,~=1.10',
+    install_requires=['dmod-core>=0.11.0', 'websockets>=10.1', 'jsonschema', 'redis', 'pydantic>=1.10.8,~=1.10',
                       'Deprecated',
                       'ngen-config@git+https://github.com/noaa-owp/ngen-cal@master#egg=ngen-config&subdirectory=python/ngen_conf'],
     packages=find_namespace_packages(include=['dmod.*'], exclude=['dmod.test'])

--- a/python/services/dataservice/dmod/dataservice/service.py
+++ b/python/services/dataservice/dmod/dataservice/service.py
@@ -576,7 +576,7 @@ class ServiceManager(WebSocketInterface):
             reason = 'Unsupported {} Query Type - {}'.format(DatasetQuery.__class__.__name__, query_type.name)
             return DatasetManagementResponse(action=message.management_action, success=False, reason=reason)
 
-    async def listener(self, websocket: WebSocketServerProtocol, path):
+    async def listener(self, websocket: WebSocketServerProtocol):
         """
         Process incoming messages over the websocket and respond appropriately.
         """

--- a/python/services/monitorservice/dmod/monitorservice/service.py
+++ b/python/services/monitorservice/dmod/monitorservice/service.py
@@ -459,7 +459,7 @@ class WebSocketMonitorService(MonitorService, WebSocketInterface):
         """
         return self._websockets_by_connection[connection_id]
 
-    async def listener(self, websocket: WebSocketServerProtocol, path):
+    async def listener(self, websocket: WebSocketServerProtocol):
         """
         Handle a connection to a party that wants to receive updates about jobs as changes are monitored, sending update
         messages back over the maintained websocket as appropriate.
@@ -475,7 +475,6 @@ class WebSocketMonitorService(MonitorService, WebSocketInterface):
         Parameters
         ----------
         websocket
-        path
         """
         connection_id = None
         try:

--- a/python/services/partitionerservice/dmod/partitionerservice/service.py
+++ b/python/services/partitionerservice/dmod/partitionerservice/service.py
@@ -407,7 +407,7 @@ class ServiceManager(HydrofabricFilesManager, WebSocketInterface):
         """
         return self._hydrofabrics_root_dir
 
-    async def listener(self, websocket: WebSocketServerProtocol, path):
+    async def listener(self, websocket: WebSocketServerProtocol):
         """
         Listen for and process partitioning requests.
 
@@ -415,8 +415,6 @@ class ServiceManager(HydrofabricFilesManager, WebSocketInterface):
         ----------
         websocket : WebSocketServerProtocol
             Websocket over which the request was sent and response should be sent.
-
-        path
 
         Returns
         -------

--- a/python/services/requestservice/dmod/requestservice/service.py
+++ b/python/services/requestservice/dmod/requestservice/service.py
@@ -172,7 +172,7 @@ class RequestService(WebSocketSessionsInterface):
     def session_manager(self):
         return self._session_manager
 
-    async def listener(self, websocket: WebSocketServerProtocol, path):
+    async def listener(self, websocket: WebSocketServerProtocol):
         """
         Async function listening for incoming information on websocket.
         """
@@ -193,7 +193,7 @@ class RequestService(WebSocketSessionsInterface):
                     response = await self._evaluation_service_handler.handle_request(
                         request=req_message,
                         socket=websocket,
-                        path=path
+                        path=websocket.path
                     )
                     logging.debug('************************* Handled request response: {}'.format(str(response)))
                     await websocket.send(str(response))

--- a/python/services/schedulerservice/dmod/schedulerservice/service.py
+++ b/python/services/schedulerservice/dmod/schedulerservice/service.py
@@ -312,7 +312,7 @@ class SchedulerHandler(WebSocketInterface):
         return JobControlResponse(action=JobControlAction.STOP, job_id=job_id, success=False,
                                   reason="Timeout Wait For Stop", message=f"Timeout of {timedelta!s} reached.")
 
-    async def listener(self, websocket: WebSocketServerProtocol, path):
+    async def listener(self, websocket: WebSocketServerProtocol):
         """
         Process incoming messages, for things like ::class:`Job` requests or updates, via a listened-for websocket,
         kicking off the appropriate actions and sending the appropriate response or responses back via the websocket.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ docker
 django-generate
 jsonschema
 redis
-websockets
+websockets>=10.1
 Faker
 flake8
 autopep8


### PR DESCRIPTION
`path` parameter was deprecated in [`websockets` `v10.1`](https://websockets.readthedocs.io/en/stable/project/changelog.html#id20). Remove this from the `WebSocketInterface` `listen` method and from all implementations.

Im happy to version bump, but im not sure it is necessary. Thoughts, @robertbartel?