### PR TITLE
Fix bugs discovered in testing

### DIFF
--- a/python/lib/modeldata/dmod/test/it_object_store_dataset_manager.py
+++ b/python/lib/modeldata/dmod/test/it_object_store_dataset_manager.py
@@ -68,8 +68,8 @@ class IntegrationTestObjectStoreDatasetManager(unittest.TestCase):
 
         self._secrets_dir: Path = Path(self.find_git_root_dir()).joinpath("docker/secrets/")
         if self._secrets_dir.exists():
-            self._access_key = self._secrets_dir.joinpath("object_store/model_exec_access_key").read_text()
-            self._secret_key = self._secrets_dir.joinpath("object_store/model_exec_secret_key").read_text()
+            self._access_key = self._secrets_dir.joinpath("object_store/model_exec_access_key").read_text().strip()
+            self._secret_key = self._secrets_dir.joinpath("object_store/model_exec_secret_key").read_text().strip()
         else:
             self._access_key = os.environ.get("MODEL_EXEC_ACCESS_KEY")
             assert self._access_key is not None, "'MODEL_EXEC_ACCESS_KEY' environment variable or 'docker/secrets/object_store/model_exec_access_key' file is required"

--- a/python/lib/modeldata/dmod/test/setup_it_env.sh
+++ b/python/lib/modeldata/dmod/test/setup_it_env.sh
@@ -22,6 +22,13 @@ do_setup()
     if [ $(./scripts/control_stack.sh object_store check) = 'false' ]; then
         touch .bring_down_obj_store
         ./scripts/control_stack.sh object_store deploy
+        for srv in $(docker stack services object_store --format "{{.Name}}"); do
+            echo "Waiting for ${srv} service to fully start ..."
+            while [ $(docker service ls --format "{{.Name}}: {{.Mode}} online:{{.Replicas}}" | grep ${srv} | grep -v online:0 | wc -l) -lt 1 ]; do
+                docker service ls --format "{{.Name}}: {{.Mode}} online:{{.Replicas}}" | grep ${srv}
+                sleep 3
+            done
+        done
     fi
 }
 

--- a/python/lib/scheduler/dmod/scheduler/resources/resource_manager.py
+++ b/python/lib/scheduler/dmod/scheduler/resources/resource_manager.py
@@ -362,4 +362,5 @@ class ResourceManager(ABC):
                 if not isinstance(alloc, ResourceAllocation):
                     self.release_resources(allocations)
                     return [None]
+                allocations.append(alloc)
         return allocations

--- a/python/lib/scheduler/dmod/test/scheduler_test_utils.py
+++ b/python/lib/scheduler/dmod/test/scheduler_test_utils.py
@@ -1,5 +1,5 @@
-from dmod.scheduler.job import RequestedJob
-from dmod.scheduler.resources import Resource, ResourceAllocation, ResourceManager
+from ..scheduler.job import RequestedJob
+from ..scheduler.resources import Resource, ResourceAllocation, ResourceManager
 from dmod.communication import NWMRequest, NGENRequest, SchedulerRequestMessage
 from dmod.core.meta_data import DataCategory, DataDomain, DataFormat, DataRequirement, DiscreteRestriction
 from uuid import uuid4


### PR DESCRIPTION
- Fixing issue with tests for object store dataset manager, where an extra line in Docker secrets files for object store credentials would previously break functionality
- Improving integration test helper script for _dmod.modeldata_ to wait for object store services to fully start before running the tests that needed them started
- Fixing an import related bug in _dmod.scheduler_ tests that was breaking behavior through the tests, because an `isinstance` call was failing due to the same _actual_ class getting imported different ways in different parts of the code
- Fix a bug in the recently updated round robin allocation function, to make sure it actually collects and returns the allocations that it allocates