### PR TITLE
Fix bind host value setup for data service.

### DIFF
--- a/docker/main/dataservice/entrypoint.sh
+++ b/docker/main/dataservice/entrypoint.sh
@@ -23,4 +23,4 @@ if [ -d ${UPDATED_PACKAGES_DIR:=/updated_packages} ]; then
     fi
 fi
 
-python -m uvicorn dmod.dataservice.rest_service:app --host "${HOST:?HOST not set}"--port "${PORT:?PORT not set}" --ssl-keyfile="${KEY_PATH?:KEY_PATH not set}" --ssl-certfile="${CERT_PATH:?CERT_PATH not set}"
+python -m uvicorn dmod.dataservice.rest_service:app --host "${HOST:?HOST not set}" --port "${PORT:?PORT not set}" --ssl-keyfile="${KEY_PATH?:KEY_PATH not set}" --ssl-certfile="${CERT_PATH:?CERT_PATH not set}"

--- a/docker/main/docker-deploy.yml
+++ b/docker/main/docker-deploy.yml
@@ -165,6 +165,7 @@ services:
       - SSL_DIR=/ssl/data-service
       - OBJECT_STORE_HOST=${DMOD_DATA_SERVICE_OBJ_STORE_HOST:-minio-proxy}
       - REDIS_HOST=${DOCKER_REDIS_SERVICE_ALIAS:-myredis}
+      - HOST=${DOCKER_DATA_SERVICE_LISTEN_HOST:-0.0.0.0}
       # computed or optional variables. optional vars have associated default value
       # - S3FS_URL_PROTOCOL='http'
       # - S3FS_URL_HOST
@@ -173,7 +174,6 @@ services:
       # - S3FS_VOL_IMAGE_TAG='latest'
       # - S3FS_PLUGIN_ALIAS='s3fs'
       # - S3FS_HELPER_NETWORK='host'
-      # - HOST # computed with `hostname`
       # - REDIS_PORT=6379
       # - OBJECT_STORE_PORT=9000
       # debugging configuration

--- a/example.env
+++ b/example.env
@@ -400,6 +400,9 @@ DOCKER_GUI_MAAS_ENDPOINT_HOST=nwm-master_request-service
 ## The listening port for websocket communication for the dataservice container
 DOCKER_DATASERVICE_CONTAINER_PORT=3020
 
+# The bind host value for the service, passed as an arg to uvicorn in the entrypoint script
+#DOCKER_DATA_SERVICE_LISTEN_HOST=
+
 ## The bound port on the host for the GUI stack web server service container.
 ## Essentially, this is the port where the application can be accessed.
 ## This is handled by default in the compose file if not set.


### PR DESCRIPTION
Add env var `HOST` to _data-service_ Docker config, as the entrypoint script requires this in the environment. 
Having this Docker env var be sourced from a DMOD deployment env var `DOCKER_DATA_SERVICE_LISTEN_HOST` (or fall back to default of 0.0.0.0) and adding this new DMOD env var to example.env.

Also, fixing typo in start of _uvicorn_ in entrypoint script, where there was no space between bind host arg and `--port` flag.
