### PR TITLE
fix(scripts): support mac version of nproc

### DIFF
--- a/scripts/create_env_config.sh
+++ b/scripts/create_env_config.sh
@@ -15,7 +15,12 @@ fi
 
 # TODO: provide args to optionally parameterize JOBS_CPU_COUNT (while still sanity checking against nproc)
 if [ -z "${JOBS_CPU_COUNT:-}" ]; then
-    _TOTAL_CPU=$(nproc)
+    # `nproc` is not natively supported on mac
+    if [ $(uname -s) = 'Darwin' ]; then
+        _TOTAL_CPU=$(sysctl -n hw.ncpu)
+    else
+        _TOTAL_CPU=$(nproc)
+    fi
     if [ ${_TOTAL_CPU} -lt 2 ]; then
         JOBS_CPU_COUNT=1
     elif [ ${_TOTAL_CPU} -lt 8 ]; then


### PR DESCRIPTION
`nproc` is not natively supported on mac. This causes `scripts/create_env_config.sh` to fail if you run on mac. This PR adds mac support.