### PR TITLE
Updated Redis Connections to use the correct credentials

### DIFF
--- a/python/gui/utilities/communication.py
+++ b/python/gui/utilities/communication.py
@@ -32,13 +32,13 @@ def get_redis_connection(
         A connection to a redis instance
     """
     construction_arguments = {
-        key: value
-        for key, value in kwargs.items()
+        "host": host or application_values.REDIS_HOST,
+        "port": port or application_values.REDIS_PORT,
+        **kwargs
     }
 
-    construction_arguments['host'] = host or application_values.REDIS_HOST
-    construction_arguments['port'] = port or application_values.REDIS_PORT
-    construction_arguments['password'] = password or application_values.REDIS_PASSWORD
+    if password or application_values.REDIS_PASSWORD:
+        construction_arguments["password"] = password or application_values.REDIS_PASSWORD
 
     if db or application_values.REDIS_DB:
         construction_arguments['db'] = db or application_values.REDIS_DB

--- a/python/services/evaluationservice/dmod/evaluationservice/kill_runner.py
+++ b/python/services/evaluationservice/dmod/evaluationservice/kill_runner.py
@@ -12,8 +12,10 @@ class Arguments(object):
     def __init__(self, *args):
         self.__host: typing.Optional[str] = None
         self.__port: typing.Optional[str] = None
+        self.__username: typing.Optional[str] = None
         self.__password: typing.Optional[str] = None
         self.__channel: typing.Optional[str] = None
+        self.__db: int = 0
         self.__parse_command_line(*args)
 
     @property
@@ -25,8 +27,16 @@ class Arguments(object):
         return self.__port
 
     @property
+    def username(self) -> typing.Optional[str]:
+        return self.__username
+
+    @property
     def password(self) -> typing.Optional[str]:
         return self.__password
+
+    @property
+    def db(self) -> int:
+        return self.__db
 
     @property
     def channel(self) -> typing.Optional[str]:
@@ -37,20 +47,40 @@ class Arguments(object):
 
         # Add options
 
-        parser.add_argument('--redis-host',
-                            help='Set the host value for making Redis connections',
-                            dest='redis_host',
-                            default=None)
+        parser.add_argument(
+            '--redis-host',
+            help='Set the host value for making Redis connections',
+            dest='redis_host',
+            default=None
+        )
 
-        parser.add_argument('--redis-pass',
-                            help='Set the password value for making Redis connections',
-                            dest='redis_pass',
-                            default=None)
+        parser.add_argument(
+            '--redis-port',
+            help='Set the port value for making Redis connections',
+            dest='redis_port',
+            default=None
+        )
 
-        parser.add_argument('--redis-port',
-                            help='Set the port value for making Redis connections',
-                            dest='redis_port',
-                            default=None)
+        parser.add_argument(
+            '--redis-username',
+            help='Set the username for making Redis connections',
+            dest='redis_username',
+            default=None
+        )
+
+        parser.add_argument(
+            '--redis-pass',
+            help='Set the password value for making Redis connections',
+            dest='redis_pass',
+            default=None
+        )
+
+        parser.add_argument(
+            '--redis-db',
+            help='Set the database value for making Redis connections',
+            dest='redis_db',
+            default=None
+        )
 
         parser.add_argument(
             "--channel",
@@ -65,10 +95,12 @@ class Arguments(object):
             parameters = parser.parse_args()
 
         # Assign parsed parameters to member variables
-        self.__host = parameters.redis_host or service.RQ_HOST
-        self.__port = parameters.redis_port or service.RQ_PORT
-        self.__password = parameters.redis_pass or service.REDIS_PASSWORD
+        self.__host = parameters.redis_host or service.RUNNER_HOST
+        self.__port = parameters.redis_port or service.RUNNER_PORT
+        self.__username = parameters.redis_username or service.RUNNER_USERNAME
+        self.__password = parameters.redis_pass or service.RUNNER_PASSWORD
         self.__channel = parameters.channel or service.EVALUATION_QUEUE_NAME
+        self.__db = parameters.db or service.REDIS_DB
 
 
 def main():
@@ -79,7 +111,9 @@ def main():
     connection_parameters = {
         "host": arguments.host,
         "port": arguments.port,
-        "password": arguments.password
+        "username": arguments.username,
+        "password": arguments.password,
+        "db": arguments.db,
     }
     with utilities.get_redis_connection(**connection_parameters) as connection:
         payload = {

--- a/python/services/evaluationservice/dmod/evaluationservice/service/__init__.py
+++ b/python/services/evaluationservice/dmod/evaluationservice/service/__init__.py
@@ -2,15 +2,28 @@ from .logging import debug
 from .logging import info
 from .logging import error
 from .logging import warn
+from .logging import ConfiguredLogger
 
 from .application_values import APPLICATION_NAME
 from .application_values import COMMON_DATETIME_FORMAT
 from .application_values import EVALUATION_QUEUE_NAME
+
 from .application_values import REDIS_HOST
 from .application_values import REDIS_PORT
+from .application_values import REDIS_USERNAME
 from .application_values import REDIS_PASSWORD
-from .application_values import RQ_HOST
-from .application_values import RQ_PORT
+from .application_values import REDIS_DB
+
+from .application_values import RUNNER_HOST
+from .application_values import RUNNER_PORT
+from .application_values import RUNNER_USERNAME
+from .application_values import RUNNER_PASSWORD
+from .application_values import RUNNER_DB
+
 from .application_values import CHANNEL_HOST
 from .application_values import CHANNEL_PORT
+from .application_values import CHANNEL_USERNAME
+from .application_values import CHANNEL_PASSWORD
+from .application_values import CHANNEL_DB
+
 from .application_values import CHANNEL_NAME_PATTERN

--- a/python/services/evaluationservice/dmod/evaluationservice/service/application_values.py
+++ b/python/services/evaluationservice/dmod/evaluationservice/service/application_values.py
@@ -46,13 +46,17 @@ def get_redis_password(password_path_variable: str = None, password_variable_nam
     The optional environment variables that control this are `REDIS_PASSWORD_FILE` for the secret or `REDIS_PASS`
     for the password on its own.
 
+    Args:
+        password_path_variable: The path to the secrets file for the password.
+        password_variable_name: The name of the environment variable for the password.
+
     Returns:
         The optional password to the core redis service
     """
-    if password_path_variable is None:
-        password_path_variable = "REDIS_PASSWORD_FILE"
-
-    password_filename = os.environ.get(password_path_variable, "/run/secrets/myredis_pass")
+    password_filename = os.environ.get(
+        password_path_variable or "REDIS_PASSWORD_FILE",
+        "/run/secrets/myredis_pass"
+    )
 
     # If a password file has been identified, try to get a password from that
     if os.path.exists(password_filename):
@@ -66,11 +70,8 @@ def get_redis_password(password_path_variable: str = None, password_variable_nam
             # Data couldn't be read? Move on to attempting to read it from the environment variable
             pass
 
-    if not password_variable_name:
-        password_variable_name = "REDIS_PASS"
-
     # Fall back to env if no secrets file, further falling back to default if no env value
-    return os.environ.get(password_variable_name)
+    return os.environ.get(password_variable_name or "REDIS_PASS")
 
 
 def get_full_localtimezone():

--- a/python/services/evaluationservice/dmod/evaluationservice/utilities/__init__.py
+++ b/python/services/evaluationservice/dmod/evaluationservice/utilities/__init__.py
@@ -1,6 +1,10 @@
 from .common import *
 from .communication import RedisCommunicator
+
 from .communication import get_redis_connection
+from .communication import get_runner_connection
+from .communication import get_channel_connection
+
 from .communication import redis_prefix
 from .communication import get_channel_key
 from .communication import get_evaluation_pointers

--- a/python/services/evaluationservice/dmod/evaluationservice/utilities/communication.py
+++ b/python/services/evaluationservice/dmod/evaluationservice/utilities/communication.py
@@ -173,11 +173,11 @@ def get_runner_connection(
         A connection to a redis instance
     """
     return redis.Redis(
-        host=host or application_values.REDIS_HOST,
-        port=port or application_values.REDIS_PORT,
-        username=username or application_values.REDIS_USERNAME,
-        password=password or application_values.REDIS_PASSWORD,
-        db=db or application_values.REDIS_DB,
+        host=host or application_values.RUNNER_HOST,
+        port=port or application_values.RUNNER_PORT,
+        username=username or application_values.RUNNER_USERNAME,
+        password=password or application_values.RUNNER_PASSWORD,
+        db=db or application_values.RUNNER_DB,
     )
 
 

--- a/python/services/evaluationservice/dmod/evaluationservice/utilities/communication.py
+++ b/python/services/evaluationservice/dmod/evaluationservice/utilities/communication.py
@@ -122,23 +122,92 @@ def unchecked_lifespan() -> int:
     return int(timedelta(hours=18).total_seconds())
 
 
-def get_redis_connection(host: str = None, port: int = None, password: str = None, **kwargs) -> redis.Redis:
+def get_redis_connection(
+    host: str = None,
+    port: int = None,
+    username: str = None,
+    password: str = None,
+    db: int = None
+) -> redis.Redis:
     """
     Forms a connection to a redis instance. If fields are not supplied, values fall back to environment configuration
 
     Args:
         host: The optional host to connect to
         port: The optional port to connect to
+        username: The optional username to connect to
         password: The optional password to use when connecting to the instance
-        **kwargs:
+        db: The optional database to connect to
 
     Returns:
         A connection to a redis instance
     """
     return redis.Redis(
-        host=host or application_values.RQ_HOST,
-        port=port or application_values.RQ_PORT,
-        password=password or application_values.REDIS_PASSWORD
+        host=host or application_values.REDIS_HOST,
+        port=port or application_values.REDIS_PORT,
+        username=username or application_values.REDIS_USERNAME,
+        password=password or application_values.REDIS_PASSWORD,
+        db=db or application_values.REDIS_DB,
+    )
+
+
+def get_runner_connection(
+    host: str = None,
+    port: int = None,
+    db: str = None,
+    password: str = None,
+    username: str = None
+) -> redis.Redis:
+    """
+    Forms a connection to a redis instance to the runner. If fields are not supplied,
+    values fall back to environment configuration
+
+    Args:
+        host: The optional host to connect to
+        port: The optional port to connect to
+        username: The optional username to connect to
+        password: The optional password to use when connecting to the instance
+        db: The optional database to connect to
+
+    Returns:
+        A connection to a redis instance
+    """
+    return redis.Redis(
+        host=host or application_values.REDIS_HOST,
+        port=port or application_values.REDIS_PORT,
+        username=username or application_values.REDIS_USERNAME,
+        password=password or application_values.REDIS_PASSWORD,
+        db=db or application_values.REDIS_DB,
+    )
+
+
+def get_channel_connection(
+    host: str = None,
+    port: int = None,
+    db: str = None,
+    password: str = None,
+    username: str = None
+) -> redis.Redis:
+    """
+    Forms a connection to a redis instance that serves channel information. If fields are not supplied,
+    values fall back to environment configuration
+
+    Args:
+        host: The optional host to connect to
+        port: The optional port to connect to
+        username: The optional username to connect to
+        password: The optional password to use when connecting to the instance
+        db: The optional database to connect to
+
+    Returns:
+        A connection to a redis instance
+    """
+    return redis.Redis(
+        host=host or application_values.CHANNEL_HOST,
+        port=port or application_values.CHANNEL_PORT,
+        username=username or application_values.CHANNEL_USERNAME,
+        password=password or application_values.CHANNEL_PASSWORD,
+        db=db or application_values.CHANNEL_DB,
     )
 
 


### PR DESCRIPTION
Actions taken previously were scattered between using a default redis password and redis hosts and ports for a defunct RQ configuration. That has been changed so that the elements connected to channels are connected to credentials for channels, elements connected to the runner are connected to the credentials for the runner, and elements connected to just redis by default are connected to the right credentials.

closes #649 