### PR TITLE
fix: `dmod.communication` version regression

### DIFF
--- a/python/services/schedulerservice/setup.py
+++ b/python/services/schedulerservice/setup.py
@@ -17,6 +17,6 @@ setup(
     author_email='',
     url='',
     license='',
-    install_requires=['dmod-core>=0.17.0', 'dmod-communication>=0.20.1', 'dmod-scheduler>=0.13.0'],
+    install_requires=['dmod-core>=0.17.0', 'dmod-communication>=0.20.0', 'dmod-scheduler>=0.13.0'],
     packages=find_namespace_packages(exclude=['dmod.test', 'deprecated', 'conf', 'schemas', 'ssl', 'src'])
     )


### PR DESCRIPTION
`dmod.schedulerservice` was depending on `dmod.communication` version (`0.20.1`) that does not exist (yet), latest version is `0.20.0`. 

Looks like this was mistakenly introduced in 3cbe5a19. Sorry I didn't catch it in review!