### PR TITLE
Update update_package.sh

### DIFF
--- a/scripts/update_package.sh
+++ b/scripts/update_package.sh
@@ -72,6 +72,13 @@ Options:
     echo "${_O}" 2>&1
 }
 
+check_and_install_wheel() {
+    if ! pip show wheel > /dev/null 2>&1; then
+        echo "wheel package is not installed. Installing..."
+        pip install wheel
+    fi
+}
+
 init_package_dirs_array_when_empty()
 {
     # Only initialize if nothing was provided (i.e., via command line args)
@@ -208,6 +215,9 @@ py_dev_activate_venv
 
 # Trap to make sure we "clean up" script activity before exiting
 trap cleanup_before_exit 0 1 2 3 6 15
+
+# Ensure wheel is installed
+check_and_install_wheel
 
 # After setting VENV, if set to get dependencies, do that, optionally exiting after if that's all we are set to do
 if [ -n "${DO_DEPS:-}" ]; then


### PR DESCRIPTION
fixes the issue #680 and makes sure the project doesn't break due to wheel.

## Additions

Added a check_and_install_wheel function to update_package.sh to ensure the wheel package is installed before attempting to build packages.

## Removals

-

## Changes

Modified update_package.sh to call the check_and_install_wheel function before any package building commands.

## Testing

Ran the update_package.sh script without wheel installed to ensure it gets installed automatically. Verified that the script completes successfully and packages are built and installed correctly.

## Screenshots

-

## Notes

-

## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [ ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] No linting errors or warnings
