### PR TITLE
ci(integration): install service packages

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -74,7 +74,7 @@ jobs:
           deactivate
           export PROJECT_ROOT=$(pwd)
           echo ${PROJECT_ROOT}
-          ./scripts/update_package.sh --venv dmod_venv --no-service-packages --dependencies
+          ./scripts/update_package.sh --venv dmod_venv --dependencies
 
       - name: Cache Package Checksums
         id: cache-packages-md5


### PR DESCRIPTION
Identical fix to #575 (2ed48)

[Integration tests are failing](https://github.com/NOAA-OWP/DMOD/actions/runs/10253857745/job/28410913531) b.c. service packages are not being installed.

Fairly sure that I will need to manually clear the runner caches for this to work.