### PR TITLE
ci: add `pre-commit` ci action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,16 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Add gh ci action to enforce `pre-commit` rules.

TODO(future):

It is desirable that `pre-commit` ci failures that are fixable could also be handled by a gh ci bot. For example, if the `pre-commit` ci job fails it would be great if you could submit comment a comment like `ci: fix`, and have another action run and apply the fixes. There are several projects that could accomplish this (e.g. [`pre-commit` lite](https://pre-commit.ci/lite.html), [`pre-commit.ci`](https://pre-commit.ci/)), however they appear to require installing github apps at the org or repo level and I've not looked into these options enough to pursue either option yet. It may be the case that a self-rolled solution is possible that does not require installing a github app.