### PR TITLE
Support basic, locally-defined customizations to worker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,8 @@ schedulerservice/test/test_scheduler.py_old
 
 node_modules/
 .next/
+
+# Ignore things within ngen worker customization directory, except of course the readme file
+docker/main/ngen/customize/*
+!docker/main/ngen/customize/README.md
+!docker/main/ngen/customize/clone_and_cmake_build.sh

--- a/docker/main/ngen/Dockerfile
+++ b/docker/main/ngen/Dockerfile
@@ -876,6 +876,40 @@ ENTRYPOINT ["entrypoint.sh"]
 
 ################################################################################################################
 ################################################################################################################
+##### User customization build stage
+FROM rocky-ngen-deps as build_customizations
+
+ARG WORKDIR
+ARG NGEN_BUILD_CONFIG_TYPE
+ENV NGEN_BUILD_CONFIG_TYPE=${NGEN_BUILD_CONFIG_TYPE}
+
+COPY --chown=${USER} --from=pre_build_bmi_iso_c_fortran_dep ${WORKDIR}/iso_c_fortran_bmi ${WORKDIR}/iso_c_fortran_bmi
+
+ENV PATH=${WORKDIR}:${WORKDIR}/bin:/dmod/bin:${PATH}:/usr/lib64/mpich/bin
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/lib:/usr/local/lib64:/dmod/shared_libs
+ENV NETCDFINC=/usr/include
+ENV VIRTUAL_ENV=/dmod/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Copy customization script and any other included artifacts (plus README, to make sure something is always there)
+COPY customize/* ${WORKDIR}
+
+# Install packages from a requirements.txt if present
+RUN if [ -e ${WORKDIR}/requirements.txt ]; then pip3 install -r ${WORKDIR}/requirements.txt ; fi
+
+# Clone, build, and install simple CMake-buildable repos if the list is present
+RUN if [ -e ${WORKDIR}/cmake_repositories.txt ]; then \
+        chmod ugo+x ${WORKDIR}/clone_and_cmake_build.sh ; \
+        for _REPO_URL in $(cat ${WORKDIR}/cmake_repositories.txt); do \
+            ${WORKDIR}/clone_and_cmake_build.sh ${_REPO_URL} ; \
+        done ; \
+    fi
+
+# If the user script exists and was copied, execute it
+RUN if [ -e ${WORKDIR}/customize.sh ]; then chmod ugo+x ${WORKDIR}/customize.sh && ${WORKDIR}/customize.sh ; fi
+
+################################################################################################################
+################################################################################################################
 ##### Model exec ngen worker image build stage
 #FROM rocky_build_ngen AS ngen_worker
 FROM rocky-base AS ngen_worker
@@ -904,6 +938,9 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY --chown=${USER} --from=build_bmi_lgar_c /dmod/ /dmod/
 COPY --chown=${USER} --from=build_bmi_sac_sma /dmod/ /dmod/
 COPY --chown=${USER} --from=build_bmi_snow_17 /dmod/ /dmod/
+
+#  Copy libs data, etc. from customize layer
+COPY --chown=${USER} --from=build_customizations /dmod/ /dmod/
 
 USER root
 # Update path and make sure dataset directory is there

--- a/docker/main/ngen/customize/README.md
+++ b/docker/main/ngen/customize/README.md
@@ -1,0 +1,48 @@
+# Locally Customizing the ngen Worker
+
+It simply isn't possible to bundle every possible ngen-compatible BMI module into the job worker image Dockerfile.  As such, the source Dockerfile doesn't try to include everything and only integrates a small number of OWP-developed BMI modules.  
+
+But, it is possible to use other BMI modules outside this small subset in the DMOD job worker images.
+
+Several special files can be added to this directory in a local copy of the repo that will enable customization of the built job worker Docker images.  The regular image building process for DMOD is designed to use these files, when present, to incorporate customizations into the worker images.  One or more may be used in combination, or none can be used and the "stock" image will be built.
+
+These special files are configured to be ignored by Git, keeping them from being committed to the repo and allowing them to be unique to each situation.
+
+In summary, it is possible to:
+- provide a `requirements.txt` file to customize what Python packages are installed
+- list external Git repositories to clone and build via a file, though this will only work in situations meeting some specific criteria
+- provide a specialized script to manually perform more advanced or nuanced customization
+
+## Supply `requirements.txt` File
+
+If a `requirements.txt` file is present within this directory, it will be used by an additional call to `pip` during the image build process, installing the Python packages listed within the file.  This is likely the easiest way to incorporate more Python BMI modules, as long as they are publicly accessible.  
+
+Keep in mind that, even if ready-made packages are not available via something like PyPI, `pip` supports [installing directly from version control systems](https://pip.pypa.io/en/stable/topics/vcs-support/) like Git.
+
+## List of Repos Built By Helper Script
+
+Users can locally create a file named `cmake_repositories.txt` in this directory and add a list of Git URLs for repos supporting building with CMake.
+
+If a `cmake_repositories.txt` file is added in this directory, each line will be treated as Git URL and run through the `clone_and_cmake_build.sh` helper script.  Though it can only handle very simple use cases, this script will automatically clone the repo, build shared libraries and other artifacts, and put these things into appropriate places in the built image.  While limited, it may be useful for things like C or C++ BMI modules.
+
+For this to work for a provided Git repo, a few conditions must hold true:
+
+- the Git repository must be accessible at the given URL anonymously
+- the script doesn't provide a branch, so whatever the default branch is (e.g., `master` or `main`) must be suitable
+- the contents of the repo must be set up to build with **CMake**
+- no extra, deliberate configuration of **CMake** variables should be necessary 
+  - (except `CMAKE_BUILD_TYPE` and `CMAKE_INSTALL_PREFIX`, which are pre-set in the script)
+- running `cmake --build <build_dir>` will build anything/everything required
+  - i.e., it must not be necessary to build a specific **CMake** `target`
+
+## Use Manual Customization Script 
+
+If the above methods are insufficient, it is possible to write a more bespoke script for configuring whatever customization is needed within the image, while also avoiding commiting this script directly to the repo.  This allows for finer-grained control but also puts more responsibility on the user.  To do this:
+
+1. Create a script named `customize.sh` within this directory
+2. Have the script do whatever cloning, configuring, building, etc. tasks are necessary
+3. Make sure built artifacts (libraries, executables, static data/config files) are placed within `/dmod/` subdirectories within the image build so that `ngen` can find them
+   1. `/dmod/bin/` for executables
+   2. `/dmod/bmi_module_data/` for static module data and configs
+   3. `/dmod/shared_libs/` for compiled shared libraries
+   4. Note that there is also a Python virtual environment at `/dmod/venv/`, though this should be active in the environment when the script is run; i.e., installing packages using `pip` should get things there without any extra steps

--- a/docker/main/ngen/customize/clone_and_cmake_build.sh
+++ b/docker/main/ngen/customize/clone_and_cmake_build.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+REPO_URL="${1:?No repo URL provided}"
+
+if [ -e "./repo_dir" ]; then
+    rm --preserve-root -rf "./repo_dir"
+fi
+
+# Clone the repo, but only the primary branch
+git clone --single-branch ${REPO_URL} repo_dir
+cd repo_dir || exit 1
+
+# Generate a CMake build system and build
+cmake -B ./cmake_build -DCMAKE_BUILD_TYPE=${NGEN_BUILD_CONFIG_TYPE:-Release} -DCMAKE_INSTALL_PREFIX:PATH=/dmod -S .
+cmake --build ./cmake_build
+
+# Move libraries within the /dmod/ directory so they'll be copied into later image build stage
+mkdir -p /dmod/lib64
+mkdir -p /dmod/shared_libs
+cp -a ./cmake_build/*.so* /dmod/lib64/.
+cp -a ./cmake_build/*.so* /dmod/shared_libs/.


### PR DESCRIPTION
Adding some simple mechanisms to support limited customization of job worker images.  The primary intended use case is to allow for additional types of BMI modules to be available for use in `ngen` jobs.